### PR TITLE
Remove unused import

### DIFF
--- a/iohub/cli/cli.py
+++ b/iohub/cli/cli.py
@@ -1,5 +1,3 @@
-import sys
-
 import click
 
 from iohub._version import __version__


### PR DESCRIPTION
Removes unused import in the CLI module that breaks CI.