### PR TITLE
Gather FOVs into plates

### DIFF
--- a/iohub/ngff.py
+++ b/iohub/ngff.py
@@ -1239,6 +1239,79 @@ class Row(NGFFNode):
 class Plate(NGFFNode):
     _MEMBER_TYPE = Row
 
+    @classmethod
+    def from_positions(
+        cls,
+        store_path: StrOrBytesPath,
+        positions: dict[str, Position],
+    ) -> Plate:
+        """Create a new HCS store from existing OME-Zarr stores
+        by copying images and metadata from a dictionary of positions.
+
+        .. warning: This assumes same channel names and axes across the FOVs
+            and does not check for consistent shape and chunk size.
+
+        Parameters
+        ----------
+        store_path : StrOrBytesPath
+            Path of the new store
+        positions : dict[str, Position]
+            Dictionary where keys are destination path names ('row/column/fov')
+            and values are :py:class:`iohub.ngff.Position` objects.
+
+        Returns
+        -------
+        Plate
+            New plate with copied data
+
+        Examples
+        --------
+        Combine an HCS-layout store and an FOV-layout store:
+
+        >>> from iohub.ngff import open_ome_zarr, Plate
+
+        >>> with open_ome_zarr("hcs.zarr") as old_plate:
+        >>>     fovs = dict(old_plate.positions())
+
+        >>> with open_ome_zarr("fov.zarr") as old_position:
+        >>>     fovs["Z/1/0"] = old_position
+
+        >>> new_plate = Plate.from_positions("combined.zarr", fovs)
+        """
+        # get metadata from an arbitraty FOV
+        # deterministic because dicts are ordered
+        example_position = next(iter(positions.values()))
+        plate = open_ome_zarr(
+            store_path,
+            layout="hcs",
+            mode="w-",
+            channel_names=example_position.channel_names,
+            axes=example_position.axes,
+            version=example_position.version,
+        )
+        for name, src_pos in positions.items():
+            if not isinstance(src_pos, Position):
+                raise TypeError(
+                    f"Expected item type {type(Position)}, "
+                    f"got {type(src_pos)}"
+                )
+            name = normalize_storage_path(name)
+            if name in plate.zgroup:
+                raise FileExistsError(
+                    f"Duplicate name '{name}' after path normalization."
+                )
+            row, col, fov = name.split("/")
+            _ = plate.create_position(row, col, fov)
+            # overwrite position group
+            _ = zarr.copy_store(
+                src_pos.zgroup.store,
+                plate.zgroup.store,
+                source_path=src_pos.zgroup.name,
+                dest_path=name,
+                if_exists="replace",
+            )
+        return plate
+
     def __init__(
         self,
         group: zarr.Group,

--- a/tests/ngff/test_ngff.py
+++ b/tests/ngff/test_ngff.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
 from iohub.ngff import (
     TO_DICT_SETTINGS,
+    Plate,
     TransformationMeta,
     _open_store,
     _pad_shape,
@@ -622,3 +623,21 @@ def test_position_scale(channels_and_random_5d):
     ) as dataset:
         # round-trip test with the offical reader implementation
         assert dataset.scale == scale
+
+
+def test_combine_fovs_to_hcs(setup_test_data, setup_hcs_ref):
+    fovs = {}
+    fov_paths = ("A/1/0", "B/1/0", "H/12/9")
+    for path in fov_paths:
+        with open_ome_zarr(setup_hcs_ref) as hcs_store:
+            fovs[path] = hcs_store["B/03/0"]
+    with TemporaryDirectory() as temp_dir:
+        store_path = os.path.join(temp_dir, "combined.zarr")
+        combined_plate = Plate.from_positions(store_path, fovs)
+        # read data with an external reader
+        ext_reader = Reader(parse_url(combined_plate.zgroup.store.path))
+        node = list(ext_reader())[0]
+        plate_meta = node.metadata["metadata"]["plate"]
+        assert len(plate_meta["rows"]) == 3
+        assert len(plate_meta["columns"]) == 2
+        assert node.data[0].shape == (1, 2, 2160 * 3, 5120 * 2)

--- a/tests/ngff/test_ngff.py
+++ b/tests/ngff/test_ngff.py
@@ -557,6 +557,7 @@ def test_get_channel_index(setup_test_data, setup_hcs_ref, wrong_channel_name):
 @given(
     row=short_alpha_numeric, col=short_alpha_numeric, pos=short_alpha_numeric
 )
+@settings(max_examples=16, deadline=2000)
 def test_modify_hcs_ref(setup_test_data, setup_hcs_ref, row, col, pos):
     """Test `iohub.ngff.open_ome_zarr()`"""
     with _temp_copy(setup_hcs_ref) as store_path:


### PR DESCRIPTION
~Proposed solution for #141 in https://github.com/czbiohub/iohub/issues/141#issuecomment-1575062339.~
Edit: The mantis project has decided to create the Zarr hierarchy before distributed processing. So this PR no longer requires review from that perspective. However, I think it is still useful for combining existing datasets in general, and this pooling can potentially benefit projects such as machine learning.

Usage pattern:

```py
from iohub.ngff import open_ome_zarr, Plate

# all FOVs from an HCS store
with open_ome_zarr("hcs.zarr") as old_plate:
    fovs = dict(old_plate.positions())

# FOV from a standalone FOV store
with open_ome_zarr("fov.zarr") as old_position:
    fovs["Z/1/0"] = old_position

new_plate = Plate.from_positions("combined.zarr", fovs)
```