### PR TITLE
Update NDTIFF reader

### DIFF
--- a/iohub/ndtiff.py
+++ b/iohub/ndtiff.py
@@ -140,24 +140,13 @@ class NDTiffReader(ReaderBase):
         # TODO: try casting the dask array into a zarr array
         # using `dask.array.to_zarr()`.
         # Currently this call brings the data into memory
-
-        ax = [
-            ax_
-            for ax_ in ["position", "time", "channel", "z"]
-            if ax_ in self._axes
-        ]
-
-        if "position" in self._axes.keys():
-            # da is Dask array
-            da = self.dataset.as_array(axes=ax, position=position)
-        else:
-            if position not in (0, None):
-                warnings.warn(
-                    f"Position index {position} is not part of this dataset."
-                    f" Returning data at default position."
-                )
-            da = self.dataset.as_array(axes=ax)
-
+        if "position" not in self._axes.keys() and position not in (0, None):
+            warnings.warn(
+                f"Position index {position} is not part of this dataset. "
+                "Returning data at the default position."
+            )
+            position = None
+        da = self.dataset.as_array(position=position)
         shape = (
             self.frames,
             self.channels,
@@ -165,7 +154,7 @@ class NDTiffReader(ReaderBase):
             self.height,
             self.width,
         )
-
+        # add singleton axes so output is 5D
         return da.reshape(shape)
 
     def get_array(self, position: int) -> np.ndarray:

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     pydantic>=1.10.2
     tifffile>=2023.2.3, <2023.3.15
     natsort>=7.1.1
-    ndtiff>=1.9.0
+    ndtiff>=2.1.0
     zarr>=2.13
     tqdm
     pillow>=9.4.0


### PR DESCRIPTION
Resolves #124.

This bumps `ndtiff` to 2.1.0 so that we can use the automatic axes sorting instead of pulling our own.

Currently CI only tests for NDTIFFv2 datasets. @ieivanov Should we add some v3 datasets to the pool?