### PR TITLE
Release timing requirement for I/O-heavy test

### DIFF
--- a/tests/ngff/test_ngff.py
+++ b/tests/ngff/test_ngff.py
@@ -208,7 +208,11 @@ def test_write_ome_zarr(channels_and_random_5d, arr_name):
     ch_shape_dtype=_channels_and_random_5d_shape_and_dtype(),
     arr_name=short_alpha_numeric,
 )
-@settings(max_examples=16, deadline=2000)
+@settings(
+    max_examples=16,
+    deadline=2000,
+    suppress_health_check=[HealthCheck.data_too_large],
+)
 def test_create_zeros(ch_shape_dtype, arr_name):
     """Test `iohub.ngff.Position.create_zeros()`"""
     channel_names, shape, dtype = ch_shape_dtype

--- a/tests/ngff/test_ngff.py
+++ b/tests/ngff/test_ngff.py
@@ -556,6 +556,7 @@ def test_get_channel_index(setup_test_data, setup_hcs_ref, wrong_channel_name):
 @given(
     row=short_alpha_numeric, col=short_alpha_numeric, pos=short_alpha_numeric
 )
+@settings(max_examples=16, deadline=2000)
 def test_modify_hcs_ref(setup_test_data, setup_hcs_ref, row, col, pos):
     """Test `iohub.ngff.open_ome_zarr()`"""
     with _temp_copy(setup_hcs_ref) as store_path:


### PR DESCRIPTION
This test has been causing flakiness in CI (e.g. [this run](https://github.com/czbiohub-sf/iohub/actions/runs/5261313496/jobs/9509282931)). This PR releases timing requirement from 200 ms to 2000 ms and limits the max examples to 16.