### PR TITLE
Use correct color when substring matches color name

### DIFF
--- a/tests/test_display_utils.py
+++ b/tests/test_display_utils.py
@@ -6,6 +6,9 @@ def test_channel_display_settings():
     channel_name = "GFP"
     channel_meta = channel_display_settings(channel_name)
     assert channel_meta.color == "00FF00"
+    channel_name = "GFP EX488 EM525-45"
+    channel_meta = channel_display_settings(channel_name)
+    assert channel_meta.color == "00FF00"
     channel_name = "S0"
     channel_meta = channel_display_settings(channel_name)
     assert channel_meta.color == "FFFFFF"


### PR DESCRIPTION
This quality-of-life improvement lets iohub match the correct colors when the channel name is not an exact match to the color dictionary. 

For example:
**Before:** `GFP EX488 EM525-45` would not be colored green because it did not exactly match `GFP`
**After:** `GFP EX488 EM525-45` is colored green because it `GFP` is a substring of the channel name.