### PR TITLE
Pin zarr version to avoid tifffile issue

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     tifffile>=2023.2.3, <2023.3.15
     natsort>=7.1.1
     ndtiff>=2.1.0
-    zarr>=2.13
+    zarr>=2.13, <2.16
     tqdm
     pillow>=9.4.0
     blosc2


### PR DESCRIPTION
Zarr 2.16 introduces a change related to tifffile. Since we pinned tifffile to an older version this may have broke our TIFF converters.

Temporarily mitigates #164 