### PR TITLE
Convert image metadata for ND-TIFF

### DIFF
--- a/docs/source/api/mm_converter.rst
+++ b/docs/source/api/mm_converter.rst
@@ -1,13 +1,13 @@
 Convert TIFF to OME-Zarr
 ========================
 
-.. currentmodule:: iohub.convert
-
 
 .. note:: There is also a CLI command for conversion.
    Consult ``iohub convert --help`` for documentation.
 
 
+.. currentmodule:: iohub.convert
+
+
 .. autoclass:: TIFFConverter
    :members:
-   :inherited-members:

--- a/iohub/convert.py
+++ b/iohub/convert.py
@@ -467,7 +467,7 @@ class TIFFConverter:
                 all_ndtiff_metadata[frame_key] = image_metadata
         self.writer.zgroup.attrs.update(self.metadata)
         with open(
-            os.path.join(self.output_dir, "NDTiff_meta.json"), mode="x"
+            os.path.join(self.output_dir, "ndtiff_metadata.json"), mode="x"
         ) as metadata_file:
             json.dump(all_ndtiff_metadata, metadata_file)
         self.writer.close()

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -163,7 +163,7 @@ def test_converter_ndtiff(
                 _check_scale_transform(pos, scale_voxels)
                 intensity += pos["0"][:].sum()
         assert intensity == raw_array.sum()
-        with open(os.path.join(output, "NDTiff_meta.json")) as f:
+        with open(os.path.join(output, "ndtiff_metadata.json")) as f:
             metadata = json.load(f)
             assert len(metadata) == np.prod(raw_array.shape[:-2])
             key = pos_name + "/0/0/0/0"


### PR DESCRIPTION
Converts ND-TIFF image plane metadata to `converted.zarr/ndtiff_metadata.json`.

Resolves #168.