### PR TITLE
Convert ND-TIFF position label

### DIFF
--- a/iohub/cli/cli.py
+++ b/iohub/cli/cli.py
@@ -82,14 +82,7 @@ def info(files, verbose):
     is_flag=True,
     help="Arrange FOVs in a row/column grid layout for tiled acquisition",
 )
-@click.option(
-    "--label-positions",
-    "-p",
-    required=False,
-    is_flag=True,
-    help="Dump postion labels in MM metadata to Omero metadata",
-)
-def convert(input, output, format, scale_voxels, grid_layout, label_positions):
+def convert(input, output, format, scale_voxels, grid_layout):
     """Converts Micro-Manager TIFF datasets to OME-Zarr"""
     converter = TIFFConverter(
         input_dir=input,
@@ -97,6 +90,5 @@ def convert(input, output, format, scale_voxels, grid_layout, label_positions):
         data_type=format,
         scale_voxels=scale_voxels,
         grid_layout=grid_layout,
-        label_positions=label_positions,
     )
     converter.run()

--- a/iohub/ndtiff.py
+++ b/iohub/ndtiff.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Union
+from typing import Literal, Union
 
 import numpy as np
 import zarr
@@ -18,7 +18,8 @@ class NDTiffReader(ReaderBase):
 
         self.dataset = Dataset(data_path)
         self._axes = self.dataset.axes
-
+        self._str_posistion_axis = self._check_str_axis("position")
+        self._str_channel_axis = self._check_str_axis("channel")
         self.frames = (
             len(self._axes["time"]) if "time" in self._axes.keys() else 1
         )
@@ -82,6 +83,23 @@ class NDTiffReader(ReaderBase):
                 pm_metadata["StagePositions"].append(position_metadata)
 
         return {"Summary": pm_metadata}
+
+    def _check_str_axis(self, axis: Literal["position", "channel"]) -> bool:
+        if axis in self._axes:
+            coord_sample = next(iter(self._axes[axis]))
+            return isinstance(coord_sample, str)
+        else:
+            return False
+
+    @property
+    def str_position_axis(self) -> bool:
+        """Position axis is string-valued"""
+        return self._str_posistion_axis
+
+    @property
+    def str_channel_axis(self) -> bool:
+        """Channel axis is string-valued"""
+        return self._str_channel_axis
 
     def _check_coordinates(
         self, p: Union[int, str], t: int, c: Union[int, str], z: int

--- a/iohub/reader_base.py
+++ b/iohub/reader_base.py
@@ -127,8 +127,9 @@ class ReaderBase:
             ]
             return [(well[0], well[1:], fov) for well, fov in labels]
         except Exception:
+            labels = [pos.get("Label") for pos in self.stage_positions]
             raise ValueError(
                 "HCS position labels are in the format of "
                 "'A1-Site_0', 'H12-Site_1', ... "
-                f"Got labels {[pos['Label'] for pos in self.stage_positions]}"
+                f"Got labels {labels}"
             )

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -84,18 +84,17 @@ def test_cli_info_ome_zarr(setup_test_data, setup_hcs_ref, verbose):
     assert re.search(r"Wells:\s+1", result.output)
 
 
-@given(f=st.booleans(), g=st.booleans(), p=st.booleans(), s=st.booleans())
+@given(f=st.booleans(), g=st.booleans(), s=st.booleans())
 @settings(
     suppress_health_check=[HealthCheck.function_scoped_fixture], deadline=20000
 )
 def test_cli_convert_ome_tiff(
-    setup_test_data, setup_mm2gamma_ome_tiffs, f, g, p, s
+    setup_test_data, setup_mm2gamma_ome_tiffs, f, g, s
 ):
     _, _, input_dir = setup_mm2gamma_ome_tiffs
     runner = CliRunner()
     f = "-f ometiff" if f else ""
     g = "-g" if g else ""
-    p = "-p" if p else ""
     with TemporaryDirectory() as tmp_dir:
         output_dir = os.path.join(tmp_dir, "converted.zarr")
         cmd = ["convert", "-i", input_dir, "-o", output_dir, "-s", s]
@@ -103,8 +102,6 @@ def test_cli_convert_ome_tiff(
             cmd += ["-f", "ometiff"]
         if g:
             cmd += ["-g"]
-        if p:
-            cmd += ["-p"]
         result = runner.invoke(cli, cmd)
     assert result.exit_code == 0
     assert "Status" in result.output

--- a/tests/ngff/test_ngff.py
+++ b/tests/ngff/test_ngff.py
@@ -562,8 +562,11 @@ def test_get_channel_index(setup_test_data, setup_hcs_ref, wrong_channel_name):
     row=short_alpha_numeric, col=short_alpha_numeric, pos=short_alpha_numeric
 )
 @settings(max_examples=16, deadline=2000)
-def test_modify_hcs_ref(setup_test_data, setup_hcs_ref, row, col, pos):
+def test_modify_hcs_ref(
+    setup_test_data, setup_hcs_ref, row: str, col: str, pos: str
+):
     """Test `iohub.ngff.open_ome_zarr()`"""
+    assume((row.lower() != "b"))
     with _temp_copy(setup_hcs_ref) as store_path:
         with open_ome_zarr(store_path, layout="hcs", mode="r+") as dataset:
             assert dataset.axes[0].name == "c"

--- a/tests/reader/test_pycromanager.py
+++ b/tests/reader/test_pycromanager.py
@@ -80,5 +80,14 @@ def test_get_num_positions(setup_test_data, setup_pycromanager_test_data):
 def test_v3_labeled_positions(ndtiff_v3_labeled_positions):
     data_dir: str = ndtiff_v3_labeled_positions
     reader = NDTiffReader(data_dir)
+    assert reader.str_position_axis
+    assert not reader.str_channel_axis
     position_labels = [pos["Label"] for pos in reader.stage_positions]
     assert position_labels == ["Pos0", "Pos1", "Pos2"]
+
+
+def test_v2_non_str_axis(setup_test_data, setup_pycromanager_test_data):
+    first_dir, rand_dir, ptcz_dir = setup_pycromanager_test_data
+    reader = NDTiffReader(rand_dir)
+    assert not reader.str_position_axis
+    assert not reader.str_channel_axis

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -26,7 +26,6 @@ CONVERTER_TEST_SETTINGS = settings(
 
 CONVERTER_TEST_GIVEN = dict(
     grid_layout=st.booleans(),
-    label_positions=st.booleans(),
     scale_voxels=st.booleans(),
 )
 
@@ -46,7 +45,6 @@ def test_converter_ometiff(
     setup_test_data,
     setup_mm2gamma_ome_tiffs,
     grid_layout,
-    label_positions,
     scale_voxels,
 ):
     logging.getLogger("tifffile").setLevel(logging.ERROR)
@@ -57,7 +55,6 @@ def test_converter_ometiff(
             data,
             output,
             grid_layout=grid_layout,
-            label_positions=label_positions,
             scale_voxels=scale_voxels,
         )
         assert isinstance(converter.reader, MicromanagerOmeTiffReader)
@@ -133,7 +130,6 @@ def test_converter_ndtiff(
     setup_test_data,
     setup_pycromanager_test_data,
     grid_layout,
-    label_positions,
     scale_voxels,
 ):
     logging.getLogger("tifffile").setLevel(logging.ERROR)
@@ -144,7 +140,6 @@ def test_converter_ndtiff(
             data,
             output,
             grid_layout=grid_layout,
-            label_positions=label_positions,
             scale_voxels=scale_voxels,
         )
         assert isinstance(converter.reader, NDTiffReader)
@@ -171,13 +166,28 @@ def test_converter_ndtiff(
             assert "ElapsedTime-ms" in metadata[key]
 
 
+def test_converter_ndtiff_v3_position_labels(
+    ndtiff_v3_labeled_positions,
+):
+    with TemporaryDirectory() as tmp_dir:
+        output = os.path.join(tmp_dir, "converted.zarr")
+        converter = TIFFConverter(ndtiff_v3_labeled_positions, output)
+        converter.run(check_image=True)
+        with open_ome_zarr(output, mode="r") as result:
+            assert result.channel_names == ["0"]
+            assert [name.split("/")[1] for name, _ in result.positions()] == [
+                "Pos0",
+                "Pos1",
+                "Pos2",
+            ]
+
+
 @given(**CONVERTER_TEST_GIVEN)
 @settings(CONVERTER_TEST_SETTINGS)
 def test_converter_singlepagetiff(
     setup_test_data,
     setup_mm2gamma_singlepage_tiffs,
     grid_layout,
-    label_positions,
     scale_voxels,
     caplog,
 ):
@@ -189,7 +199,6 @@ def test_converter_singlepagetiff(
             data,
             output,
             grid_layout=grid_layout,
-            label_positions=label_positions,
             scale_voxels=scale_voxels,
         )
         assert isinstance(converter.reader, MicromanagerSequenceReader)


### PR DESCRIPTION
Convert non-HCS string-valued ND-TIFF position coordinate into column names of an HCS OME-Zarr store.