### PR TITLE
Print scale in `iohub info`

### DIFF
--- a/iohub/reader.py
+++ b/iohub/reader.py
@@ -271,7 +271,7 @@ def print_info(path: StrOrBytesPath, verbose=False):
                 f"Channels:\t {reader.shape[1]}",
                 ch_msg,
                 f"(Z, Y, X) shape:\t {reader.shape[2:]}",
-                f"(Z, Y, X) scale (um):\t {[reader.z_step_size, reader.xy_pixel_size, reader.xy_pixel_size]}",
+                f"(Z, Y, X) scale (um):\t {(reader.z_step_size, reader.xy_pixel_size, reader.xy_pixel_size)}",
             ]
         )
         if verbose:
@@ -316,6 +316,6 @@ def print_info(path: StrOrBytesPath, verbose=False):
         if isinstance(reader, Position) or verbose:
             print("Zarr hierarchy:")
             reader.print_tree()
-            print(f"\n(Z, Y, X) scale:\t {reader.scale[2:]}")
+            print(f"\n(Z, Y, X) scale (um):\t {tuple(reader.scale[2:])}")
         print("\n".join(msgs))
         reader.close()

--- a/iohub/reader.py
+++ b/iohub/reader.py
@@ -270,9 +270,8 @@ def print_info(path: StrOrBytesPath, verbose=False):
                 f"Time points:\t {reader.shape[0]}",
                 f"Channels:\t {reader.shape[1]}",
                 ch_msg,
-                f"(Z, Y, X):\t {reader.shape[2:]}",
-                f"XY pixel size (um):\t {reader.xy_pixel_size}",
-                f"Z step (um):\t {reader.z_step_size}",
+                f"(Z, Y, X) shape:\t {reader.shape[2:]}",
+                f"(Z, Y, X) scale (um):\t {[reader.z_step_size, reader.xy_pixel_size, reader.xy_pixel_size]}",
             ]
         )
         if verbose:
@@ -317,6 +316,6 @@ def print_info(path: StrOrBytesPath, verbose=False):
         if isinstance(reader, Position) or verbose:
             print("Zarr hierarchy:")
             reader.print_tree()
-            print(f"\nScale:\t {reader.scale}")
+            print(f"\n(Z, Y, X) scale:\t {reader.scale[2:]}")
         print("\n".join(msgs))
         reader.close()

--- a/iohub/reader.py
+++ b/iohub/reader.py
@@ -260,6 +260,12 @@ def print_info(path: StrOrBytesPath, verbose=False):
     sum_msg = "\n=== Summary ==="
     ch_msg = f"Channel names:\t {reader.channel_names}"
     code_msg = "\nThis datset can be opened with iohub in Python code:\n"
+    zyx_scale = (
+        reader.z_step_size,
+        reader.xy_pixel_size,
+        reader.xy_pixel_size,
+    )
+
     msgs = []
     if isinstance(reader, ReaderBase):
         msgs.extend(
@@ -271,7 +277,7 @@ def print_info(path: StrOrBytesPath, verbose=False):
                 f"Channels:\t {reader.shape[1]}",
                 ch_msg,
                 f"(Z, Y, X) shape:\t {reader.shape[2:]}",
-                f"(Z, Y, X) scale (um):\t {(reader.z_step_size, reader.xy_pixel_size, reader.xy_pixel_size)}",
+                f"(Z, Y, X) scale (um):\t {zyx_scale}",
             ]
         )
         if verbose:

--- a/iohub/reader.py
+++ b/iohub/reader.py
@@ -271,6 +271,7 @@ def print_info(path: StrOrBytesPath, verbose=False):
                 f"Channels:\t {reader.shape[1]}",
                 ch_msg,
                 f"(Z, Y, X):\t {reader.shape[2:]}",
+                f"XY pixel size (um):\t {reader.xy_pixel_size}",
                 f"Z step (um):\t {reader.z_step_size}",
             ]
         )
@@ -316,5 +317,6 @@ def print_info(path: StrOrBytesPath, verbose=False):
         if isinstance(reader, Position) or verbose:
             print("Zarr hierarchy:")
             reader.print_tree()
+            print(f"\nScale:\t {reader.scale}")
         print("\n".join(msgs))
         reader.close()

--- a/iohub/reader.py
+++ b/iohub/reader.py
@@ -253,12 +253,12 @@ def print_info(path: StrOrBytesPath, verbose=False):
     except (ValueError, RuntimeError):
         print("Error: No compatible dataset is found.", file=sys.stderr)
         return
-    fmt_msg = f"Format:\t\t {fmt}"
+    fmt_msg = f"Format:\t\t\t {fmt}"
     if extra_info:
         if extra_info.startswith("0."):
             fmt_msg += " v" + extra_info
     sum_msg = "\n=== Summary ==="
-    ch_msg = f"Channel names:\t {reader.channel_names}"
+    ch_msg = f"Channel names:\t\t {reader.channel_names}"
     code_msg = "\nThis datset can be opened with iohub in Python code:\n"
     msgs = []
     if isinstance(reader, ReaderBase):
@@ -271,9 +271,9 @@ def print_info(path: StrOrBytesPath, verbose=False):
             [
                 sum_msg,
                 fmt_msg,
-                f"Positions:\t {reader.get_num_positions()}",
-                f"Time points:\t {reader.shape[0]}",
-                f"Channels:\t {reader.shape[1]}",
+                f"Positions:\t\t {reader.get_num_positions()}",
+                f"Time points:\t\t {reader.shape[0]}",
+                f"Channels:\t\t {reader.shape[1]}",
                 ch_msg,
                 f"(Z, Y, X) shape:\t {reader.shape[2:]}",
                 f"(Z, Y, X) scale (um):\t {zyx_scale}",
@@ -294,7 +294,7 @@ def print_info(path: StrOrBytesPath, verbose=False):
                 sum_msg,
                 fmt_msg,
                 "".join(
-                    ["Axes:\t\t "]
+                    ["Axes:\t\t\t "]
                     + [f"{a.name} ({a.type}); " for a in reader.axes]
                 ),
                 ch_msg,
@@ -304,15 +304,15 @@ def print_info(path: StrOrBytesPath, verbose=False):
             meta = reader.metadata
             msgs.extend(
                 [
-                    f"Row names:\t {[r.name for r in meta.rows]}",
-                    f"Column names:\t {[c.name for c in meta.columns]}",
-                    f"Wells:\t\t {len(meta.wells)}",
+                    f"Row names:\t\t {[r.name for r in meta.rows]}",
+                    f"Column names:\t\t {[c.name for c in meta.columns]}",
+                    f"Wells:\t\t\t {len(meta.wells)}",
                 ]
             )
             if verbose:
                 print("Zarr hierarchy:")
                 reader.print_tree()
-                msgs.append(f"Positions:\t {len(list(reader.positions()))}")
+                msgs.append(f"Positions:\t\t {len(list(reader.positions()))}")
         else:
             msgs.append(f"(Z, Y, X) scale (um):\t {tuple(reader.scale[2:])}")
         if verbose:

--- a/iohub/reader.py
+++ b/iohub/reader.py
@@ -309,21 +309,22 @@ def print_info(path: StrOrBytesPath, verbose=False):
                     f"Wells:\t\t {len(meta.wells)}",
                 ]
             )
+            if verbose:
+                print("Zarr hierarchy:")
+                reader.print_tree()
+                msgs.append(f"Positions:\t {len(list(reader.positions()))}")
+        else:
+            msgs.append(f"(Z, Y, X) scale (um):\t {tuple(reader.scale[2:])}")
         if verbose:
             msgs.extend(
                 [
-                    f"Positions:\t {len(list(reader.positions()))}",
                     code_msg,
                     ">>> from iohub import open_ome_zarr",
                     f">>> dataset = open_ome_zarr('{path}', mode='r')",
                 ]
             )
-            print("Zarr hierarchy:")
-            reader.print_tree()
-
         if isinstance(reader, Position):
             print("Zarr hierarchy:")
             reader.print_tree()
-            print(f"\n(Z, Y, X) scale (um):\t {tuple(reader.scale[2:])}")
         print("\n".join(msgs))
         reader.close()

--- a/iohub/reader.py
+++ b/iohub/reader.py
@@ -318,7 +318,10 @@ def print_info(path: StrOrBytesPath, verbose=False):
                     f">>> dataset = open_ome_zarr('{path}', mode='r')",
                 ]
             )
-        if isinstance(reader, Position) or verbose:
+            print("Zarr hierarchy:")
+            reader.print_tree()
+
+        if isinstance(reader, Position):
             print("Zarr hierarchy:")
             reader.print_tree()
             print(f"\n(Z, Y, X) scale (um):\t {tuple(reader.scale[2:])}")

--- a/iohub/reader.py
+++ b/iohub/reader.py
@@ -283,8 +283,8 @@ def print_info(path: StrOrBytesPath, verbose=False):
             msgs.extend(
                 [
                     code_msg,
-                    ">>> from iohub import imread",
-                    f">>> reader = imread('{path}')",
+                    ">>> from iohub import read_micromanager",
+                    f">>> reader = read_micromanager('{path}')",
                 ]
             )
         print(str.join("\n", msgs))

--- a/iohub/reader.py
+++ b/iohub/reader.py
@@ -260,14 +260,13 @@ def print_info(path: StrOrBytesPath, verbose=False):
     sum_msg = "\n=== Summary ==="
     ch_msg = f"Channel names:\t {reader.channel_names}"
     code_msg = "\nThis datset can be opened with iohub in Python code:\n"
-    zyx_scale = (
-        reader.z_step_size,
-        reader.xy_pixel_size,
-        reader.xy_pixel_size,
-    )
-
     msgs = []
     if isinstance(reader, ReaderBase):
+        zyx_scale = (
+            reader.z_step_size,
+            reader.xy_pixel_size,
+            reader.xy_pixel_size,
+        )
         msgs.extend(
             [
                 sum_msg,

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -71,7 +71,7 @@ def test_cli_info_ndtiff(
     result = runner.invoke(cli, cmd)
     assert result.exit_code == 0
     assert re.search(r"Positions:\s+2", result.output)
-    assert "XY pixel size (um):" in result.output
+    assert "scale (um)" in result.output
 
 
 @given(verbose=st.booleans())
@@ -88,7 +88,8 @@ def test_cli_info_ome_zarr(setup_test_data, setup_hcs_ref, verbose):
     result_pos = runner.invoke(
         cli, ["info", os.path.join(setup_hcs_ref, "B", "03", "0")]
     )
-    assert "Scale:" in result_pos.output
+    # TODO: Fix test dataset so that this passes. See issue #72.
+    # assert "scale (um)" in result_pos.output
 
 
 @given(f=st.booleans(), g=st.booleans(), p=st.booleans(), s=st.booleans())

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -83,13 +83,11 @@ def test_cli_info_ome_zarr(setup_test_data, setup_hcs_ref, verbose):
     result = runner.invoke(cli, cmd)
     assert result.exit_code == 0
     assert re.search(r"Wells:\s+1", result.output)
-
     # Test on single position
     result_pos = runner.invoke(
         cli, ["info", os.path.join(setup_hcs_ref, "B", "03", "0")]
     )
-    # TODO: Fix test dataset so that this passes. See issue #72.
-    # assert "scale (um)" in result_pos.output
+    assert "scale (um)" in result_pos.output
 
 
 @given(f=st.booleans(), g=st.booleans(), p=st.booleans(), s=st.booleans())

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -71,6 +71,7 @@ def test_cli_info_ndtiff(
     result = runner.invoke(cli, cmd)
     assert result.exit_code == 0
     assert re.search(r"Positions:\s+2", result.output)
+    assert "XY pixel size (um):" in result.output
 
 
 @given(verbose=st.booleans())
@@ -82,6 +83,12 @@ def test_cli_info_ome_zarr(setup_test_data, setup_hcs_ref, verbose):
     result = runner.invoke(cli, cmd)
     assert result.exit_code == 0
     assert re.search(r"Wells:\s+1", result.output)
+
+    # Test on single position
+    result_pos = runner.invoke(
+        cli, ["info", os.path.join(setup_hcs_ref, "B", "03", "0")]
+    )
+    assert "Scale:" in result_pos.output
 
 
 @given(f=st.booleans(), g=st.booleans(), p=st.booleans(), s=st.booleans())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def setup_test_data():
     # Reference v0.4 HCS dataset from OME
     # See the last line of
     # https://github.com/ome/ngff/issues/140#issuecomment-1309972511
-    ome_hcs_url = "https://zenodo.org/record/7274533/files/20200812-CardiomyocyteDifferentiation14-Cycle1.zarr.zip"  # noqa
+    ome_hcs_url = "https://zenodo.org/record/8091756/files/20200812-CardiomyocyteDifferentiation14-Cycle1.zarr.zip"  # noqa
 
     # download files to temp folder
     if not os.listdir(test_data):


### PR DESCRIPTION
This PR prints a `(Z, Y, X) scale (um)` line when you call `iohub info` on an `ndtiff` dataset or an `ngff.Position`. 


Example output:
```iohub info /hpc/instruments/cm.mantis/2023_08_09_HEK_PCNA_H2B/pcna_rac1_virtual_staining_1/pcna_rac1_virtual_staining_labelfree_1/
Reading file:	 /hpc/instruments/cm.mantis/2023_08_09_HEK_PCNA_H2B/pcna_rac1_virtual_staining_1/pcna_rac1_virtual_staining_labelfree_1
Dataset opened
=== Summary ===
Format:		 ndtiff
Positions:	 216
Time points:	 1
Channels:	 1
Channel names:	 ['BF']
(Z, Y, X) shape:	 (120, 1024, 1224)
(Z, Y, X) scale (um):	 (0.143, 0.1494, 0.1494)

iohub info /hpc/projects/comp.micro/mantis/2023_08_09_HEK_PCNA_H2B/0-zarr/pcna_rac1_virtual_staining_1/pcna_rac1_virtual_staining_labelfree_1.zarr/0/0/0/
Reading file:	 /hpc/projects/comp.micro/mantis/2023_08_09_HEK_PCNA_H2B/0-zarr/pcna_rac1_virtual_staining_1/pcna_rac1_virtual_staining_labelfree_1.zarr/0/0/0
Zarr hierarchy:
/
 └── 0 (1, 1, 120, 1024, 1224) uint16

(Z, Y, X) scale (um):	 (0.143, 0.1494, 0.1494)

=== Summary ===
Format:		 omezarr v0.4
Axes:		 T (time); C (channel); Z (space); Y (space); X (space);
Channel names:	 ['BF']