### PR TITLE
Only set array transformation upon creation of FOVs

### DIFF
--- a/iohub/ngff.py
+++ b/iohub/ngff.py
@@ -771,7 +771,9 @@ class Position(NGFFNode):
                         axes=self.axes,
                         datasets=[dataset_meta],
                         name=name,
-                        coordinateTransformations=transform,
+                        coordinateTransformations=[
+                            TransformationMeta(type="identity")
+                        ],
                         metadata=extra_meta,
                     )
                 ],

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -32,7 +32,12 @@ CONVERTER_TEST_GIVEN = dict(
 
 
 def _check_scale_transform(position: Position, scale_voxels: bool):
-    tf = position.metadata.multiscales[0].coordinate_transformations[0]
+    """Check scale transformation of the highest resolution level."""
+    tf = (
+        position.metadata.multiscales[0]
+        .datasets[0]
+        .coordinate_transformations[0]
+    )
     if scale_voxels:
         assert tf.type == "scale"
         assert tf.scale[:2] == [1.0, 1.0]


### PR DESCRIPTION
Set FOV-level transformation to identity upon creation of the first array.