### PR TITLE
Enable XYZ chunking at conversion

### DIFF
--- a/iohub/cli/cli.py
+++ b/iohub/cli/cli.py
@@ -101,3 +101,6 @@ def convert(input, output, format, scale_voxels, grid_layout, chunks):
         chunks=chunks,
     )
     converter.run()
+
+if __name__ == '__main__':
+    convert()

--- a/iohub/cli/cli.py
+++ b/iohub/cli/cli.py
@@ -101,6 +101,3 @@ def convert(input, output, format, scale_voxels, grid_layout, chunks):
         chunks=chunks,
     )
     converter.run()
-
-if __name__ == '__main__':
-    convert()

--- a/iohub/cli/cli.py
+++ b/iohub/cli/cli.py
@@ -88,7 +88,7 @@ def info(files, verbose):
     required=False,
     default="XY",
     help="Zarr chunk size given as 'XY', 'XYZ', or a tuple of chunk "
-    "dimensions.",
+    "dimensions. If 'XYZ', chunk size will be limited to 500 MB.",
 )
 def convert(input, output, format, scale_voxels, grid_layout, chunks):
     """Converts Micro-Manager TIFF datasets to OME-Zarr"""

--- a/iohub/cli/cli.py
+++ b/iohub/cli/cli.py
@@ -87,7 +87,7 @@ def info(files, verbose):
     "-c",
     required=False,
     default="XY",
-    help="Zarr chunk size given as, 'XY', 'XYZ', or a tuple of chunk "
+    help="Zarr chunk size given as 'XY', 'XYZ', or a tuple of chunk "
     "dimensions.",
 )
 def convert(input, output, format, scale_voxels, grid_layout, chunks):

--- a/iohub/cli/cli.py
+++ b/iohub/cli/cli.py
@@ -82,7 +82,15 @@ def info(files, verbose):
     is_flag=True,
     help="Arrange FOVs in a row/column grid layout for tiled acquisition",
 )
-def convert(input, output, format, scale_voxels, grid_layout):
+@click.option(
+    "--chunks",
+    "-c",
+    required=False,
+    default="XY",
+    help="Zarr chunk size given as, 'XY', 'XYZ', or a tuple of chunk "
+    "dimensions.",
+)
+def convert(input, output, format, scale_voxels, grid_layout, chunks):
     """Converts Micro-Manager TIFF datasets to OME-Zarr"""
     converter = TIFFConverter(
         input_dir=input,
@@ -90,5 +98,6 @@ def convert(input, output, format, scale_voxels, grid_layout):
         data_type=format,
         scale_voxels=scale_voxels,
         grid_layout=grid_layout,
+        chunks=chunks,
     )
     converter.run()

--- a/iohub/convert.py
+++ b/iohub/convert.py
@@ -494,7 +494,7 @@ class TIFFConverter:
                 range(self.t),
                 range(self.c),
                 bar_format=bar_format_time_channel,
-                position=4,
+                position=1,
                 leave=False,
             ):
                 ndtiff_channel_idx = (

--- a/iohub/convert.py
+++ b/iohub/convert.py
@@ -339,9 +339,9 @@ class TIFFConverter:
         elif isinstance(input_chunks, tuple):
             chunks = list(input_chunks)
         elif isinstance(input_chunks, str):
-            if input_chunks.lower == "xy":
+            if input_chunks.lower() == "xy":
                 chunks = [1, 1, 1, self.y, self.x]
-            elif input_chunks.lower == "xyz":
+            elif input_chunks.lower() == "xyz":
                 chunks = [1, 1, self.z, self.y, self.x]
             else:
                 raise ValueError(f"{input_chunks} chunks are not supported.")

--- a/iohub/convert.py
+++ b/iohub/convert.py
@@ -494,7 +494,7 @@ class TIFFConverter:
                 range(self.t),
                 range(self.c),
                 bar_format=bar_format_time_channel,
-                position=1,
+                position=4,
                 leave=False,
             ):
                 ndtiff_channel_idx = (

--- a/iohub/convert.py
+++ b/iohub/convert.py
@@ -473,6 +473,7 @@ class TIFFConverter:
         # Run through every coordinate and convert in acquisition order
         logging.info("Converting Images...")
         if isinstance(self.reader, NDTiffReader):
+            all_ndtiff_metadata = {}
             for p_idx in tqdm(range(self.p), bar_format=bar_format):
                 pos_name = (
                     self.pos_names[p_idx]
@@ -494,8 +495,6 @@ class TIFFConverter:
 
                 to_zarr(dask_arr.rechunk(self.chunks), zarr_arr)
 
-                logging.info("Writing ND-TIFF image plane metadata...")
-                all_ndtiff_metadata = {}
                 for t_idx, c_idx, z_idx in product(
                     range(self.t), range(self.c), range(self.z)
                 ):
@@ -513,16 +512,18 @@ class TIFFConverter:
                         + [str(i) for i in (t_idx, c_idx, z_idx)]
                     )
                     all_ndtiff_metadata[frame_key] = image_metadata
-                with open(
-                    os.path.join(self.output_dir, "image_plane_metadata.json"),
-                    mode="a",
-                ) as metadata_file:
-                    json.dump(all_ndtiff_metadata, metadata_file, indent=4)
 
                 if check_image:
                     # Image checking is not currently supported for
                     # NDTiff readers
                     pass
+
+            logging.info("Writing ND-TIFF image plane metadata...")
+            with open(
+                os.path.join(self.output_dir, "image_plane_metadata.json"),
+                mode="x",
+            ) as metadata_file:
+                json.dump(all_ndtiff_metadata, metadata_file, indent=4)
 
         else:
             for coord in tqdm(self.coords, bar_format=bar_format):

--- a/iohub/convert.py
+++ b/iohub/convert.py
@@ -527,13 +527,11 @@ class TIFFConverter:
                     )
                     continue
 
+                data_slice = (slice(t_idx, t_idx + 1), slice(c_idx, c_idx + 1))
                 to_zarr(
-                    dask_arr[t_idx, c_idx][None, None, :].rechunk(self.chunks),
+                    dask_arr[data_slice].rechunk(self.chunks),
                     zarr_arr,
-                    region=(
-                        slice(t_idx, t_idx + 1),
-                        slice(c_idx, c_idx + 1),
-                    ),
+                    region=data_slice,
                 )
 
                 for z_idx in range(self.z):

--- a/iohub/convert.py
+++ b/iohub/convert.py
@@ -481,9 +481,11 @@ class TIFFConverter:
                     else p_idx
                 )
                 try:
-                    ndtiff_pos_idx, *_ = self.reader._check_coordinates(ndtiff_pos_idx, 0, 0, 0)
+                    ndtiff_pos_idx, *_ = self.reader._check_coordinates(
+                        ndtiff_pos_idx, 0, 0, 0
+                    )
                 except ValueError:
-                    # Log warning and continue if some positions were not 
+                    # Log warning and continue if some positions were not
                     # acquired in the dataset
                     logging.warning(
                         f"Cannot load data at position {ndtiff_pos_idx}, "

--- a/iohub/convert.py
+++ b/iohub/convert.py
@@ -475,7 +475,7 @@ class TIFFConverter:
         if isinstance(self.reader, NDTiffReader):
             for p_idx in tqdm(range(self.p), bar_format=bar_format):
                 pos_name = (
-                    self.pos_name[p_idx]
+                    self.pos_names[p_idx]
                     if self.reader.str_position_axis
                     else p_idx
                 )

--- a/iohub/convert.py
+++ b/iohub/convert.py
@@ -502,18 +502,24 @@ class TIFFConverter:
                     if self.reader.str_channel_axis
                     else c_idx
                 )
-                try:
-                    (
-                        _,
-                        ndtiff_t_idx,
-                        ndtiff_channel_idx,
-                        _,
-                    ) = self.reader._check_coordinates(
-                        ndtiff_pos_idx, t_idx, ndtiff_channel_idx, 0
-                    )
-                except ValueError:
-                    # Log warning and continue if some T/C were not
-                    # acquired in the dataset
+                # set ndtiff_t_idx and ndtiff_z_idx to None if these axes were
+                # not acquired
+                (
+                    _,
+                    ndtiff_t_idx,
+                    ndtiff_channel_idx,
+                    ndtiff_z_idx,
+                ) = self.reader._check_coordinates(
+                    ndtiff_pos_idx, t_idx, ndtiff_channel_idx, 0
+                )
+                # Log warning and continue if some T/C were not acquired in the
+                # dataset
+                if not self.reader.dataset.has_image(
+                    position=ndtiff_pos_idx,
+                    time=ndtiff_t_idx,
+                    channel=ndtiff_channel_idx,
+                    z=ndtiff_z_idx,
+                ):
                     logging.warning(
                         f"Cannot load data at timepoint {t_idx},  channel "
                         f"{c_idx}, filling with zeros. Raw data may be "

--- a/iohub/ndtiff.py
+++ b/iohub/ndtiff.py
@@ -151,12 +151,12 @@ class NDTiffReader(ReaderBase):
             else:
                 # Nothing to do if coord == None
                 if coord is not None:
-                # If coord = 0 is requested, the coordinate will be replaced
-                # with None
+                    # If coord = 0 is requested, the coordinate will be
+                    # replaced with None
                     if coord == 0:
                         coords[i] = None
-                    # If coord != 0 is requested and the axis is not part of the
-                    # dataset, ValueError will be raised
+                    # If coord != 0 is requested and the axis is not part of
+                    # the dataset, ValueError will be raised
                     else:
                         raise ValueError(
                             f"Axis {axis} is not part of this dataset"

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -110,4 +110,4 @@ def test_cli_convert_ome_tiff(
             cmd += ["-g"]
         result = runner.invoke(cli, cmd)
     assert result.exit_code == 0
-    assert "Status" in result.output
+    assert "Converting" in result.output


### PR DESCRIPTION
This PR enables XYZ chunking at zarr conversion and speeds up `ndtiff` conversion following [this](https://github.com/czbiohub-sf/compmicro-sandbox/blob/master/iohub_scripts/convert/convert_isim_fish.py) example.

Fixes #176, Fixes #177 

To use, call `iohub convert -i /path/to/input/ -o /path/to/output.zarr/ --chunks XYZ`. Z stacks may be split into multiple chunks if they are larger than `MAX_CHUNK_SIZE` bytes.

We should use this code to convert future datasets and we should also re-convert older large datasets to reduce the number of small files on our storage.

Let's build on this code and make the converter work well. So far, I've tested it only with `pytest` and latest mantis `ndtiff` datasets. Currently, the converter effectively splits into two paths, depending on whether you're converting a `ndtiff` dataset or now. I believe @ziw-liu's intension is to make all readers return a lazy dask array, similarly to how `ndtiff` works. This can be a starting point to a universal converter following the revamp of the readers as part of the Universal API.

TODO:
 - [x] Test that missing timepoints are handled correctly