### PR TITLE
Fix product integer overflow

### DIFF
--- a/iohub/convert.py
+++ b/iohub/convert.py
@@ -357,7 +357,7 @@ class TIFFConverter:
         # it's OK if a single image is larger than MAX_CHUNK_SIZE
         while (
             chunks[-3] > 1
-            and np.prod(chunks, dtype=float) * bytes_per_pixel > MAX_CHUNK_SIZE
+            and np.prod(chunks, dtype=np.int64) * bytes_per_pixel > MAX_CHUNK_SIZE
         ):
             chunks[-3] = np.ceil(chunks[-3] / 2).astype(int)
 

--- a/iohub/convert.py
+++ b/iohub/convert.py
@@ -357,7 +357,8 @@ class TIFFConverter:
         # it's OK if a single image is larger than MAX_CHUNK_SIZE
         while (
             chunks[-3] > 1
-            and np.prod(chunks, dtype=np.int64) * bytes_per_pixel > MAX_CHUNK_SIZE
+            and np.prod(chunks, dtype=np.int64) * bytes_per_pixel
+            > MAX_CHUNK_SIZE
         ):
             chunks[-3] = np.ceil(chunks[-3] / 2).astype(int)
 

--- a/iohub/convert.py
+++ b/iohub/convert.py
@@ -357,7 +357,7 @@ class TIFFConverter:
         # it's OK if a single image is larger than MAX_CHUNK_SIZE
         while (
             chunks[-3] > 1
-            and np.prod(chunks) * bytes_per_pixel > MAX_CHUNK_SIZE
+            and np.prod(chunks, dtype=float) * bytes_per_pixel > MAX_CHUNK_SIZE
         ):
             chunks[-3] = np.ceil(chunks[-3] / 2).astype(int)
 


### PR DESCRIPTION
This `np.prod` call was overflowing when converting our data and resulting in invalid chunks.