### PR TITLE
OpenCell reader extension

### DIFF
--- a/iohub/convert.py
+++ b/iohub/convert.py
@@ -310,7 +310,10 @@ class TIFFConverter:
         if self.p > 1:
             self.pos_names = []
             for p in range(self.p):
-                name = self.reader.stage_positions[p].get("Label") or p
+                try:
+                    name = self.reader.stage_positions[p]["Label"]
+                except (IndexError, KeyError):
+                    name = p
                 self.pos_names.append(name)
         else:
             self.pos_names = ["0"]

--- a/iohub/convert.py
+++ b/iohub/convert.py
@@ -311,7 +311,7 @@ class TIFFConverter:
             self.pos_names = []
             for p in range(self.p):
                 name = (
-                    self.summary_metadata["StagePositions"][p].get("Label")
+                    self.reader.stage_positions[p].get("Label")
                     or p
                 )
                 self.pos_names.append(name)

--- a/iohub/convert.py
+++ b/iohub/convert.py
@@ -310,10 +310,7 @@ class TIFFConverter:
         if self.p > 1:
             self.pos_names = []
             for p in range(self.p):
-                name = (
-                    self.reader.stage_positions[p].get("Label")
-                    or p
-                )
+                name = self.reader.stage_positions[p].get("Label") or p
                 self.pos_names.append(name)
         else:
             self.pos_names = ["0"]

--- a/iohub/multipagetiff.py
+++ b/iohub/multipagetiff.py
@@ -173,16 +173,21 @@ class MicromanagerOmeTiffReader(ReaderBase):
                 for ch in self.mm_meta["Summary"]["ChNames"]:
                     self.channel_names.append(ch)
 
-            # Parsing of data acquired with the OpenCell 
+            # Parsing of data acquired with the OpenCell
             # acquisition script on the Dragonfly miroscope
-            elif mm_version == "2.0.1 20220920" and self.mm_meta["Summary"]["Prefix"] == "raw_data":
-                file_names = set([(key[0], val[0]) for key, val in self.coord_map.items()])
+            elif (
+                mm_version == "2.0.1 20220920"
+                and self.mm_meta["Summary"]["Prefix"] == "raw_data"
+            ):
+                file_names = set(
+                    [(key[0], val[0]) for key, val in self.coord_map.items()]
+                )
 
                 if self.mm_meta["Summary"]["Positions"] > 1:
                     self._stage_positions = [None] * self.positions
 
                     for p_idx, file_name in file_names:
-                        site_idx = int(file_name.split('_')[-1].split('-')[0])
+                        site_idx = int(file_name.split("_")[-1].split("-")[0])
                         pos = self._simplify_stage_position(
                             self.mm_meta["Summary"]["StagePositions"][site_idx]
                         )

--- a/iohub/multipagetiff.py
+++ b/iohub/multipagetiff.py
@@ -209,15 +209,17 @@ class MicromanagerOmeTiffReader(ReaderBase):
                 for ch in self.mm_meta["Summary"]["ChNames"]:
                     self.channel_names.append(ch)
 
-            # dimensions based on mm metadata
-            # do not reflect final written dimensions
-            # these will change after data is loaded
             self.z_step_size = self.mm_meta["Summary"]["z-step_um"]
             self.height = self.mm_meta["Summary"]["Height"]
             self.width = self.mm_meta["Summary"]["Width"]
-            self.frames = self.mm_meta["Summary"]["Frames"]
-            self.slices = self.mm_meta["Summary"]["Slices"]
-            self.channels = self.mm_meta["Summary"]["Channels"]
+
+            # dimensions based on mm metadata
+            # do not reflect final written dimensions
+            # these set in _gather_index_maps
+            #
+            # self.frames = self.mm_meta["Summary"]["Frames"]
+            # self.slices = self.mm_meta["Summary"]["Slices"]
+            # self.channels = self.mm_meta["Summary"]["Channels"]
 
     def _simplify_stage_position(self, stage_pos: dict):
         """

--- a/iohub/multipagetiff.py
+++ b/iohub/multipagetiff.py
@@ -55,11 +55,11 @@ class MicromanagerOmeTiffReader(ReaderBase):
         # Initialize MM attributes
         self.channel_names = []
 
-        # Read MM data
-        self._set_mm_meta()
-
         # Gather index map of file, page, byte offset
         self._gather_index_maps()
+
+        # Read MM data
+        self._set_mm_meta()
 
         # if extract data, create all of the virtual zarr stores up front
         if extract_data:
@@ -170,6 +170,24 @@ class MicromanagerOmeTiffReader(ReaderBase):
                     ]  # empty strings
 
             elif mm_version == "1.4.22":
+                for ch in self.mm_meta["Summary"]["ChNames"]:
+                    self.channel_names.append(ch)
+
+            # Parsing of data acquired with the OpenCell 
+            # acquisition script on the Dragonfly miroscope
+            elif mm_version == "2.0.1 20220920" and self.mm_meta["Summary"]["Prefix"] == "raw_data":
+                file_names = set([(key[0], val[0]) for key, val in self.coord_map.items()])
+
+                if self.mm_meta["Summary"]["Positions"] > 1:
+                    self._stage_positions = [None] * self.positions
+
+                    for p_idx, file_name in file_names:
+                        site_idx = int(file_name.split('_')[-1].split('-')[0])
+                        pos = self._simplify_stage_position(
+                            self.mm_meta["Summary"]["StagePositions"][site_idx]
+                        )
+                        self._stage_positions[p_idx] = pos
+
                 for ch in self.mm_meta["Summary"]["ChNames"]:
                     self.channel_names.append(ch)
 


### PR DESCRIPTION
The OpenCell acquisition starts with a large number of positions in the position list, but only some of those are actually imaged. When we save the data, we need to use a continuous position index starting at 0 because of a Micro-manager bug: https://github.com/micro-manager/micro-manager/issues/1723, i.e. if we are imaging positions `(5, 6, 13, 12)` in the position list, they are saved with index `(0, 1, 2, 3)`. In this case, we need to parse the correct position label from the tif filename.

I've implemented this as a special version of Micro-manager metadata. If we change the MM version on the Dragonfly microscope (unlikely) or the "raw_data" prefix (also very unlikely) this code will not work an will need to be modified. I've also switched the order of `_gather_index_maps()` and `_set_mm_meta()` to make this work. I didn't see unintended consequences here, but I think this may be making some of the tests fail. @ziw-liu can you help me take a look?

cc: @Soorya19Pradeep 