### PR TITLE
Modified fluorophore color code

### DIFF
--- a/iohub/display_utils.py
+++ b/iohub/display_utils.py
@@ -8,7 +8,15 @@ from iohub.ngff_meta import ChannelMeta, WindowDict
 """ Dictionary with key works and most popular fluorescent probes """
 CHANNEL_COLORS = {
     # emission around 510-525 nm
-    "lime": ["GFP", "Green", "Alexa488", "GCaMP", "FITC", "mNeon", "MitoViewGreen"],
+    "lime": [
+        "GFP",
+        "Green",
+        "Alexa488",
+        "GCaMP",
+        "FITC",
+        "mNeon",
+        "MitoViewGreen",
+    ],
     # emission around 580 - 610 nm
     "magenta": [
         "TXR",

--- a/iohub/display_utils.py
+++ b/iohub/display_utils.py
@@ -9,48 +9,24 @@ from iohub.ngff_meta import ChannelMeta, WindowDict
 CHANNEL_COLORS = {
     # emission around 510-525 nm
     "lime": [
-        "GFP",
         "Green",
-        "Alexa488",
-        "GCaMP",
+        "GFP",
         "FITC",
         "mNeon",
-        "MitoViewGreen",
     ],
     # emission around 580 - 610 nm
     "magenta": [
+        "Magenta",
         "TXR",
         "RFP",
         "mScarlet",
         "mCherry",
-        "dTomato",
-        "magenta",
-        "Alexa568",
-        "LysotrackerRed",
     ],
     # emission around 440 - 460 nmm
-    "blue": ["DAPI", "Blue", "BFP"],
+    "blue": ["Blue", "DAPI", "BFP", "Hoechst"],
     "red": ["Red"],
-    "yellow": ["Cy3", "Yellow"],  # Emission around 540-570 nm
-    "orange": ["Orange", "Cy5", "MitoView633"],  # emission around 650-680 nm
-    "white": [
-        "S0",
-        "S1",
-        "S2",
-        "S3",
-        "S4",
-        "BF",
-        "Phase2D",
-        "Phase3D",
-        "Retardance",
-        "Orientation",
-        "State0",
-        "State1",
-        "State2",
-        "State3",
-        "State4",
-        "white",
-    ],
+    "yellow": ["Yellow", "Cy3"],  # Emission around 540-570 nm
+    "orange": ["Orange", "Cy5"],  # emission around 650-680 nm
 }
 
 

--- a/iohub/display_utils.py
+++ b/iohub/display_utils.py
@@ -8,7 +8,7 @@ from iohub.ngff_meta import ChannelMeta, WindowDict
 """ Dictionary with key works and most popular fluorescent probes """
 CHANNEL_COLORS = {
     # emission around 510-525 nm
-    "lime": ["GFP", "Green", "Alexa488", "GCaMP", "FITC", "mNeon"],
+    "lime": ["GFP", "Green", "Alexa488", "GCaMP", "FITC", "mNeon", "MitoViewGreen"],
     # emission around 580 - 610 nm
     "magenta": [
         "TXR",
@@ -16,13 +16,15 @@ CHANNEL_COLORS = {
         "mScarlet",
         "mCherry",
         "dTomato",
-        "Alexa561",
+        "magenta",
+        "Alexa568",
+        "LysotrackerRed",
     ],
     # emission around 440 - 460 nmm
     "blue": ["DAPI", "Blue", "BFP"],
     "red": ["Red"],
-    "yellow": ["Cy3"],  # Cy3 emission is at 570 nm
-    "orange": ["Orange", "Cy5"],  # Cy5 emission is at 680 nm
+    "yellow": ["Cy3", "Yellow"],  # Emission around 540-570 nm
+    "orange": ["Orange", "Cy5", "MitoView633"],  # emission around 650-680 nm
     "white": [
         "S0",
         "S1",
@@ -39,6 +41,7 @@ CHANNEL_COLORS = {
         "State2",
         "State3",
         "State4",
+        "white",
     ],
 }
 

--- a/iohub/display_utils.py
+++ b/iohub/display_utils.py
@@ -7,20 +7,22 @@ from iohub.ngff_meta import ChannelMeta, WindowDict
 
 """ Dictionary with key works and most popular fluorescent probes """
 CHANNEL_COLORS = {
+    # emission around 510-525 nm
     "lime": ["GFP", "Green", "Alexa488", "GCaMP", "FITC", "mNeon"],
+    # emission around 580 - 610 nm
     "magenta": [
         "TXR",
         "RFP",
         "mScarlet",
         "mCherry",
         "dTomato",
-        "Cy5",
         "Alexa561",
     ],
+    # emission around 440 - 460 nmm
     "blue": ["DAPI", "Blue", "BFP"],
     "red": ["Red"],
-    "orange": ["Orange", "Cy3"],
-    "yellow": ["Alexa561"],
+    "yellow": ["Cy3"],  # Cy3 emission is at 570 nm
+    "orange": ["Orange", "Cy5"],  # Cy5 emission is at 680 nm
     "white": [
         "S0",
         "S1",


### PR DESCRIPTION
Suggesting a modification of the display color for some fluorophores.

I found that Cy5 and mCherry were both plotted in magenta, when they actually have quite different emission spectrum.

Alexa561 was also listed under both magenta and yellow colors.