### PR TITLE
Save ndtiff image plane metadata per position

### DIFF
--- a/iohub/convert.py
+++ b/iohub/convert.py
@@ -462,8 +462,9 @@ class TIFFConverter:
             "Converting Timepoints/Channels: |{bar:16}|{n_fmt}/{total_fmt} "
             "(Time Remaining: {remaining}), {rate_fmt}{postfix}]"
         )
-        all_ndtiff_metadata = {}
         for p_idx in tqdm(range(self.p), bar_format=bar_format_positions):
+            position_image_plane_metadata = {}
+
             # ndtiff_pos_idx, ndtiff_t_idx, and ndtiff_channel_idx
             # may be None
             ndtiff_pos_idx = (
@@ -541,19 +542,21 @@ class TIFFConverter:
                         ndtiff_channel_idx,
                         z_idx,
                     )
-                    # row/well/fov/img/T/C/Z
+                    # T/C/Z
                     frame_key = "/".join(
-                        [zarr_arr.path]
-                        + [str(i) for i in (t_idx, c_idx, z_idx)]
+                        [str(i) for i in (t_idx, c_idx, z_idx)]
                     )
-                    all_ndtiff_metadata[frame_key] = image_metadata
+                    position_image_plane_metadata[frame_key] = image_metadata
 
-        logging.info("Writing ND-TIFF image plane metadata...")
-        with open(
-            os.path.join(self.output_dir, "image_plane_metadata.json"),
-            mode="x",
-        ) as metadata_file:
-            json.dump(all_ndtiff_metadata, metadata_file, indent=4)
+            logging.info("Writing ND-TIFF image plane metadata...")
+            # image plane metadata is save in 
+            # output_dir/row/well/fov/img/image_plane_metadata.json,
+            # e.g. output_dir/A/1/FOV0/0/image_plane_metadata.json
+            with open(
+                os.path.join(self.output_dir, zarr_arr.path, "image_plane_metadata.json"),
+                mode="x",
+            ) as metadata_file:
+                json.dump(position_image_plane_metadata, metadata_file, indent=4)
 
     def run(self, check_image: bool = True):
         """Runs the conversion.

--- a/iohub/convert.py
+++ b/iohub/convert.py
@@ -549,14 +549,18 @@ class TIFFConverter:
                     position_image_plane_metadata[frame_key] = image_metadata
 
             logging.info("Writing ND-TIFF image plane metadata...")
-            # image plane metadata is save in 
+            # image plane metadata is save in
             # output_dir/row/well/fov/img/image_plane_metadata.json,
             # e.g. output_dir/A/1/FOV0/0/image_plane_metadata.json
             with open(
-                os.path.join(self.output_dir, zarr_arr.path, "image_plane_metadata.json"),
+                os.path.join(
+                    self.output_dir, zarr_arr.path, "image_plane_metadata.json"
+                ),
                 mode="x",
             ) as metadata_file:
-                json.dump(position_image_plane_metadata, metadata_file, indent=4)
+                json.dump(
+                    position_image_plane_metadata, metadata_file, indent=4
+                )
 
     def run(self, check_image: bool = True):
         """Runs the conversion.

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -194,11 +194,14 @@ def test_converter_ndtiff(
             for pos_name, pos in result.positions():
                 _check_scale_transform(pos, scale_voxels)
                 intensity += pos["0"][:].sum()
+                assert os.path.isfile(
+                    os.path.join(output, pos_name, "0", "image_plane_metadata.json")
+                )
         assert intensity == raw_array.sum()
-        with open(os.path.join(output, "image_plane_metadata.json")) as f:
+        with open(os.path.join(output, pos_name, "0", "image_plane_metadata.json")) as f:
             metadata = json.load(f)
-            assert len(metadata) == np.prod(raw_array.shape[:-2])
-            key = pos_name + "/0/0/0/0"
+            assert len(metadata) == np.prod(raw_array.shape[1:-2])
+            key = "0/0/0"
             assert key in metadata
             assert "ElapsedTime-ms" in metadata[key]
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -195,10 +195,14 @@ def test_converter_ndtiff(
                 _check_scale_transform(pos, scale_voxels)
                 intensity += pos["0"][:].sum()
                 assert os.path.isfile(
-                    os.path.join(output, pos_name, "0", "image_plane_metadata.json")
+                    os.path.join(
+                        output, pos_name, "0", "image_plane_metadata.json"
+                    )
                 )
         assert intensity == raw_array.sum()
-        with open(os.path.join(output, pos_name, "0", "image_plane_metadata.json")) as f:
+        with open(
+            os.path.join(output, pos_name, "0", "image_plane_metadata.json")
+        ) as f:
             metadata = json.load(f)
             assert len(metadata) == np.prod(raw_array.shape[1:-2])
             key = "0/0/0"


### PR DESCRIPTION
Breaking up the ndtiff image plane metadata, which can be quite large, per position