### PR TITLE
Fix bug determining number of rows and cols

### DIFF
--- a/iohub/convert.py
+++ b/iohub/convert.py
@@ -180,21 +180,32 @@ class TIFFConverter:
             )
 
     def _get_position_coords(self):
+        """Get the position coordinates from the reader metadata.
+
+        Raises:
+            ValueError: If stage positions are not available.
+
+        Returns:
+            list: XY stage position coordinates.
+            int: Number of grid rows.
+            int: Number of grid columns.
+        """
         rows = set()
         cols = set()
-        coords_list = []
+        xy_coords = []
 
-        # TODO: read rows, cols directly from XY corods
         # TODO: account for non MM2gamma meta?
         if not self.reader.stage_positions:
             raise ValueError("Stage positions not available.")
         for idx, pos in enumerate(self.reader.stage_positions):
-            stage_pos = pos.get("XYStage") or pos.get("XY") or pos.get("XY Stage")
+            stage_pos = (
+                pos.get("XYStage") or pos.get("XY") or pos.get("XY Stage")
+            )
             if stage_pos is None:
                 raise ValueError(
                     f"Stage position is not available for position {idx}"
                 )
-            coords_list.append(stage_pos)
+            xy_coords.append(stage_pos)
             try:
                 rows.add(pos["GridRow"])
                 cols.add(pos["GridCol"])
@@ -203,7 +214,7 @@ class TIFFConverter:
                     f"Grid indices not available for position {idx}"
                 )
 
-        return coords_list, len(rows), len(cols)
+        return xy_coords, len(rows), len(cols)
 
     def _get_pos_names(self):
         """Append a list of pos names in ascending order

--- a/iohub/convert.py
+++ b/iohub/convert.py
@@ -189,7 +189,7 @@ class TIFFConverter:
         if not self.reader.stage_positions:
             raise ValueError("Stage positions not available.")
         for idx, pos in enumerate(self.reader.stage_positions):
-            stage_pos = pos.get("XYStage") or pos.get("XY")
+            stage_pos = pos.get("XYStage") or pos.get("XY") or pos.get("XY Stage")
             if stage_pos is None:
                 raise ValueError(
                     f"Stage position is not available for position {idx}"

--- a/iohub/convert.py
+++ b/iohub/convert.py
@@ -180,8 +180,8 @@ class TIFFConverter:
             )
 
     def _get_position_coords(self):
-        row_max = 0
-        col_max = 0
+        rows = set()
+        cols = set()
         coords_list = []
 
         # TODO: read rows, cols directly from XY corods
@@ -196,16 +196,14 @@ class TIFFConverter:
                 )
             coords_list.append(stage_pos)
             try:
-                row = pos["GridRow"]
-                col = pos["GridCol"]
+                rows.add(pos["GridRow"])
+                cols.add(pos["GridCol"])
             except KeyError:
                 raise ValueError(
                     f"Grid indices not available for position {idx}"
                 )
-            row_max = row if row > row_max else row_max
-            col_max = col if col > col_max else col_max
 
-        return coords_list, row_max + 1, col_max + 1
+        return coords_list, len(rows), len(cols)
 
     def _get_pos_names(self):
         """Append a list of pos names in ascending order


### PR DESCRIPTION
In the case where you image all columns at row 35 (i.e. 1x38 FOVs) of a 38x38 grid you'd end up with incorrect determination of the number of rows and columns as (35, 38). This PR fixes this bug.