### PR TITLE
Fix bug reading dragonfly acquisitions

### DIFF
--- a/iohub/mmstack.py
+++ b/iohub/mmstack.py
@@ -127,8 +127,6 @@ class MMStack(MicroManagerFOVMapping):
         self._store = series.aszarr()
         _logger.debug(f"Opened {self._store}.")
         data = da.from_zarr(zarr.open(self._store))
-        # not all positions in the position list may have been acquired
-        data = data[: self.positions]
         self.dtype = data.dtype
         img = DataArray(data, dims=raw_dims, name=self.dirname)
         xarr = img.expand_dims(
@@ -143,6 +141,8 @@ class MMStack(MicroManagerFOVMapping):
                 "smaller than the number of channels. "
                 f"Completing with fallback names: {self.channel_names}."
             )
+        # not all positions in the position list may have been acquired
+        xarr = xarr[: self.positions]
         xarr.coords["C"] = self.channel_names
         xset = xarr.to_dataset(dim="R")
         self._xdata = xset

--- a/iohub/mmstack.py
+++ b/iohub/mmstack.py
@@ -127,7 +127,7 @@ class MMStack(MicroManagerFOVMapping):
         self._store = series.aszarr()
         _logger.debug(f"Opened {self._store}.")
         data = da.from_zarr(zarr.open(self._store))
-        data = data[:self.positions] # not all positions may have been acquires
+        data = data[:self.positions] # not all positions may have been acquired
         self.dtype = data.dtype
         img = DataArray(data, dims=raw_dims, name=self.dirname)
         xarr = img.expand_dims(

--- a/iohub/mmstack.py
+++ b/iohub/mmstack.py
@@ -9,10 +9,10 @@ from warnings import catch_warnings, filterwarnings
 import dask.array as da
 import numpy as np
 import zarr
+from natsort import natsorted
 from numpy.typing import ArrayLike
 from tifffile import TiffFile
 from xarray import DataArray
-from natsort import natsorted
 
 from iohub.mm_fov import MicroManagerFOV, MicroManagerFOVMapping
 
@@ -127,7 +127,8 @@ class MMStack(MicroManagerFOVMapping):
         self._store = series.aszarr()
         _logger.debug(f"Opened {self._store}.")
         data = da.from_zarr(zarr.open(self._store))
-        data = data[:self.positions] # not all positions may have been acquired
+        # not all positions in the position list may have been acquired
+        data = data[: self.positions]
         self.dtype = data.dtype
         img = DataArray(data, dims=raw_dims, name=self.dirname)
         xarr = img.expand_dims(


### PR DESCRIPTION
This PR fixes a bug in reading data acquired with the Dragonfly acquisition pipeline.

In the Dragonfly acquisition pipeline, we start with a large position list, but not all of these positions may be acquired. The resulting `ome.tif` dataset will have a large number of positions in the MM metadata, but fewer data series. In this PR, I limit the `xdata` size to the number of actual positions acquired. The site index is only accessible from the filename. There may be a better way to get the number of tif files and their filenames than doing a glob in the root directory.