### PR TITLE
Modify warning

### DIFF
--- a/iohub/convert.py
+++ b/iohub/convert.py
@@ -336,14 +336,17 @@ class TIFFConverter:
                     if self.reader.str_channel_axis
                     else c_idx
                 )
+            missing_data_warning_issued = False
             for z_idx in range(self.z):
                 metadata = fov.frame_metadata(t=t_idx, c=c_key, z=z_idx)
                 if metadata is None:
-                    _logger.warning(
-                        f"Cannot load data at timepoint {t_idx},  channel "
-                        f"{c_idx}, filling with zeros. Raw data may be "
-                        "incomplete."
-                    )
+                    if not missing_data_warning_issued:
+                        missing_data_warning_issued = True
+                        _logger.warning(
+                            f"Cannot load data at timepoint {t_idx},  channel "
+                            f"{c_idx}, filling with zeros. Raw data may be "
+                            "incomplete."
+                        )
                     continue
                 if not sorted_keys:
                     # Sort keys, ordering keys without dashes first

--- a/tests/ngff/test_ngff.py
+++ b/tests/ngff/test_ngff.py
@@ -200,7 +200,7 @@ def test_write_ome_zarr(channels_and_random_5d, arr_name):
         # round-trip test with the offical reader implementation
         ext_reader = Reader(parse_url(dataset.zgroup.store.path))
         node = list(ext_reader())[0]
-        assert node.metadata["name"] == channel_names
+        assert node.metadata["channel_names"] == channel_names
         assert node.specs[0].datasets == [arr_name]
         assert node.data[0].shape == random_5d.shape
         assert node.data[0].dtype == random_5d.dtype


### PR DESCRIPTION
This PR cleans up the converter logging:
 * Only one warning is issued per P-T-C, rather than issuing a warning for every P-T-C-Z
 * FOV name is included in the warning message
 * Logger console output is redirected to `tqdm.write()` for cleaner output - see before and after images

Before:
<img width="680" alt="before" src="https://github.com/czbiohub-sf/iohub/assets/11934632/d3c9f940-cf19-4dff-b7ff-3fac7142dbf4">

After:
<img width="683" alt="after" src="https://github.com/czbiohub-sf/iohub/assets/11934632/422deb21-a144-4eb9-9f00-abf45004b309">