### PR TITLE
Fix docs switcher path

### DIFF
--- a/docs/source/_static/switcher.json
+++ b/docs/source/_static/switcher.json
@@ -1,10 +1,10 @@
 [
     {
         "version": "latest",
-        "url": "/main/index.html"
+        "url": "/iohub/main/index.html"
     },
     {
         "version": "v0.1.0",
-        "url": "/v0.1.0/index.html"
+        "url": "/iohub/v0.1.0/index.html"
     }
 ]


### PR DESCRIPTION
The switcher fix in #223 was missing the project root path segment.