### PR TITLE
Fixing pyramid scaling factor

### DIFF
--- a/iohub/ngff/nodes.py
+++ b/iohub/ngff/nodes.py
@@ -946,7 +946,7 @@ class Position(NGFFNode):
             for tr in transforms:
                 if tr.type == "scale":
                     for i in range(len(tr.scale))[-3:]:
-                        tr.scale[i] /= factor
+                        tr.scale[i] *= factor
 
             self.create_zeros(
                 name=str(level),

--- a/tests/pyramid/test_pyramid.py
+++ b/tests/pyramid/test_pyramid.py
@@ -18,7 +18,6 @@ def _mock_fov(
     shape: tuple[int, ...],
     scale: tuple[float, float, float],
 ) -> Position:
-
     ds_path = tmp_path / "ds.zarr"
     channels = [str(i) for i in range(shape[1])]
 
@@ -51,7 +50,6 @@ def _mock_fov(
 
 @pytest.mark.parametrize("ndim", [2, 5])
 def test_pyramid(tmp_path: Path, ndim: int) -> None:
-
     # not all shapes not divisible by 2
     shape = (2, 2, 67, 115, 128)[-ndim:]
     scale = (2, 0.5, 0.5)[-min(3, ndim) :]
@@ -79,7 +77,7 @@ def test_pyramid(tmp_path: Path, ndim: int) -> None:
             .scale
         )
         assert np.all(level_scale[:-3] == 1)
-        assert np.allclose(scale / level_scale[-3:], 2**level)
+        assert np.allclose(scale * level_scale[-3:], 2**level)
 
         assert fov.metadata.multiscales[0].datasets[level].path == str(level)
 

--- a/tests/pyramid/test_pyramid.py
+++ b/tests/pyramid/test_pyramid.py
@@ -77,7 +77,7 @@ def test_pyramid(tmp_path: Path, ndim: int) -> None:
             .scale
         )
         assert np.all(level_scale[:-3] == 1)
-        assert np.allclose(scale * level_scale[-3:], 2**level)
+        assert np.allclose(level_scale[-3:] / scale, 2**level)
 
         assert fov.metadata.multiscales[0].datasets[level].path == str(level)
 


### PR DESCRIPTION
Hi, I noticed this bug a while ago, but the change was lost in #221 

The spatial scaling should increase as we make the images smaller so they are all the same size.
This doesn't affect napari, but it does for other viewers (e.g. neuroglancer).