### PR TITLE
Export `ImageArray` from the `ngff` module

### DIFF
--- a/iohub/ngff/__init__.py
+++ b/iohub/ngff/__init__.py
@@ -1,4 +1,10 @@
 from iohub.ngff.models import TransformationMeta
 from iohub.ngff.nodes import ImageArray, Plate, Position, open_ome_zarr
 
-__all__ = ["ImageArray", "open_ome_zarr", "Plate", "Position", "TransformationMeta"]
+__all__ = [
+    "ImageArray",
+    "open_ome_zarr",
+    "Plate",
+    "Position",
+    "TransformationMeta",
+]

--- a/iohub/ngff/__init__.py
+++ b/iohub/ngff/__init__.py
@@ -1,4 +1,4 @@
 from iohub.ngff.models import TransformationMeta
-from iohub.ngff.nodes import Plate, Position, open_ome_zarr
+from iohub.ngff.nodes import Plate, Position, open_ome_zarr, ImageArray
 
-__all__ = ["open_ome_zarr", "Plate", "Position", "TransformationMeta"]
+__all__ = ["open_ome_zarr", "Plate", "Position", "TransformationMeta","ImageArray"]

--- a/iohub/ngff/__init__.py
+++ b/iohub/ngff/__init__.py
@@ -1,4 +1,4 @@
 from iohub.ngff.models import TransformationMeta
-from iohub.ngff.nodes import Plate, Position, open_ome_zarr, ImageArray
+from iohub.ngff.nodes import ImageArray, Plate, Position, open_ome_zarr
 
-__all__ = ["open_ome_zarr", "Plate", "Position", "TransformationMeta","ImageArray"]
+__all__ = ["ImageArray", "open_ome_zarr", "Plate", "Position", "TransformationMeta"]


### PR DESCRIPTION
The latest iohub will break VisCy's hcs.py as it imports the `ImageArray`.
This PR exposes `ImageArray` to support the old usecase. 

happy to modify viscy otherwise