### PR TITLE
Add decompressed OME-Zarr dataset size to iohub info

### DIFF
--- a/iohub/reader.py
+++ b/iohub/reader.py
@@ -262,11 +262,15 @@ def print_info(path: StrOrBytesPath, verbose=False):
                 print("Zarr hierarchy:")
                 reader.print_tree()
                 positions = list(reader.positions())
+                total_GB = len(positions) * (positions[0][1][0].nbytes) / 1e9
                 msgs.append(f"Positions:\t\t {len(positions)}")
                 msgs.append(f"Chunk size:\t\t {positions[0][1][0].chunks}")
+                msgs.append(f"Store Size [GB]:\t\t {total_GB:.2f}")
         else:
+            total_GB = reader["0"].nbytes / 1e9
             msgs.append(f"(Z, Y, X) scale (um):\t {tuple(reader.scale[2:])}")
             msgs.append(f"Chunk size:\t\t {reader['0'].chunks}")
+            msgs.append(f"Size [GB]:\t\t {total_GB:.2f}")
         if verbose:
             msgs.extend(
                 [

--- a/iohub/reader.py
+++ b/iohub/reader.py
@@ -262,15 +262,21 @@ def print_info(path: StrOrBytesPath, verbose=False):
                 print("Zarr hierarchy:")
                 reader.print_tree()
                 positions = list(reader.positions())
-                total_GB = len(positions) * (positions[0][1][0].nbytes) / 1e9
+                total_GB_uncompressed = (
+                    len(positions) * (positions[0][1][0].nbytes) / 1e9
+                )
                 msgs.append(f"Positions:\t\t {len(positions)}")
                 msgs.append(f"Chunk size:\t\t {positions[0][1][0].chunks}")
-                msgs.append(f"Store Size [GB]:\t\t {total_GB:.2f}")
+                msgs.append(
+                    f"Uncompressed size [GB]:\t\t {total_GB_uncompressed:.2f}"
+                )
         else:
-            total_GB = reader["0"].nbytes / 1e9
+            total_GB_uncompressed = reader["0"].nbytes / 1e9
             msgs.append(f"(Z, Y, X) scale (um):\t {tuple(reader.scale[2:])}")
             msgs.append(f"Chunk size:\t\t {reader['0'].chunks}")
-            msgs.append(f"Size [GB]:\t\t {total_GB:.2f}")
+            msgs.append(
+                f"Uncompressed size [GB]:\t\t {total_GB_uncompressed:.2f}"
+            )
         if verbose:
             msgs.extend(
                 [

--- a/iohub/reader.py
+++ b/iohub/reader.py
@@ -271,12 +271,12 @@ def print_info(path: StrOrBytesPath, verbose=False):
                 msgs.append(f"Positions:\t\t {len(positions)}")
                 msgs.append(f"Chunk size:\t\t {positions[0][1][0].chunks}")
                 msgs.append(
-                    f"No. bytes:\t\t {total_bytes_compressed:.2f} "
-                    f"[{sizeof_fmt(total_bytes_compressed)}]"
+                    f"No. bytes:\t\t {total_bytes_uncompressed:.2f} "
+                    f"[{sizeof_fmt(total_bytes_uncompressed)}]"
                 )
                 msgs.append(
-                    f"No. bytes stored:\t {total_bytes_uncompressed:.2f} "
-                    f"[{sizeof_fmt(total_bytes_uncompressed)}]"
+                    f"No. bytes stored:\t {total_bytes_compressed:.2f} "
+                    f"[{sizeof_fmt(total_bytes_compressed)}]"
                 )
         else:
             total_bytes_uncompressed = reader["0"].nbytes
@@ -284,12 +284,12 @@ def print_info(path: StrOrBytesPath, verbose=False):
             msgs.append(f"(Z, Y, X) scale (um):\t {tuple(reader.scale[2:])}")
             msgs.append(f"Chunk size:\t\t {reader['0'].chunks}")
             msgs.append(
-                f"No. bytes:\t\t {total_bytes_compressed:.2f} "
-                f"[{sizeof_fmt(total_bytes_compressed)}]"
+                f"No. bytes:\t\t {total_bytes_uncompressed:.2f} "
+                f"[{sizeof_fmt(total_bytes_uncompressed)}]"
             )
             msgs.append(
-                f"No. bytes stored:\t {total_bytes_uncompressed:.2f} "
-                f"[{sizeof_fmt(total_bytes_uncompressed)}]"
+                f"No. bytes stored:\t {total_bytes_compressed:.2f} "
+                f"[{sizeof_fmt(total_bytes_compressed)}]"
             )
         if verbose:
             msgs.extend(

--- a/iohub/reader.py
+++ b/iohub/reader.py
@@ -262,20 +262,34 @@ def print_info(path: StrOrBytesPath, verbose=False):
                 print("Zarr hierarchy:")
                 reader.print_tree()
                 positions = list(reader.positions())
-                total_GB_uncompressed = (
-                    len(positions) * (positions[0][1][0].nbytes) / 1e9
+                total_bytes_uncompressed = len(positions) * (
+                    positions[0][1][0].nbytes
+                )
+                total_bytes_compressed = len(positions) * (
+                    positions[0][1][0].nbytes_stored
                 )
                 msgs.append(f"Positions:\t\t {len(positions)}")
                 msgs.append(f"Chunk size:\t\t {positions[0][1][0].chunks}")
                 msgs.append(
-                    f"Uncompressed size [GB]:\t\t {total_GB_uncompressed:.2f}"
+                    f"No. bytes:\t\t {total_bytes_compressed:.2f} "
+                    f"[{sizeof_fmt(total_bytes_compressed)}]"
+                )
+                msgs.append(
+                    f"No. bytes stored:\t {total_bytes_uncompressed:.2f} "
+                    f"[{sizeof_fmt(total_bytes_uncompressed)}]"
                 )
         else:
-            total_GB_uncompressed = reader["0"].nbytes / 1e9
+            total_bytes_uncompressed = reader["0"].nbytes
+            total_bytes_compressed = reader["0"].nbytes_stored
             msgs.append(f"(Z, Y, X) scale (um):\t {tuple(reader.scale[2:])}")
             msgs.append(f"Chunk size:\t\t {reader['0'].chunks}")
             msgs.append(
-                f"Uncompressed size [GB]:\t\t {total_GB_uncompressed:.2f}"
+                f"No. bytes:\t\t {total_bytes_compressed:.2f} "
+                f"[{sizeof_fmt(total_bytes_compressed)}]"
+            )
+            msgs.append(
+                f"No. bytes stored:\t {total_bytes_uncompressed:.2f} "
+                f"[{sizeof_fmt(total_bytes_uncompressed)}]"
             )
         if verbose:
             msgs.extend(
@@ -290,3 +304,16 @@ def print_info(path: StrOrBytesPath, verbose=False):
             reader.print_tree()
         print("\n".join(msgs))
         reader.close()
+
+
+def sizeof_fmt(num) -> str:
+    """
+    Human readable file size
+    Borrowing form:
+    https://web.archive.org/web/20111010015624/
+    http://blogmag.net/blog/read/38/Print_human_readable_file_size
+    """
+    for x in ["bytes", "KB", "MB", "GB", "TB"]:
+        if num < 1024.0:
+            return "%3.1f%s" % (num, x)
+        num /= 1024.0

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -85,11 +85,13 @@ def test_cli_info_ome_zarr(verbose):
     assert result.exit_code == 0
     assert re.search(r"Wells:\s+1", result.output)
     assert ("Chunk size" in result.output) == bool(verbose)
+    assert ("No. bytes decompressed" in result.output) == bool(verbose)
     # Test on single position
     result_pos = runner.invoke(cli, ["info", str(hcs_ref / "B" / "03" / "0")])
     assert "Channel names" in result_pos.output
     assert "scale (um)" in result_pos.output
     assert "Chunk size" in result_pos.output
+    assert "84.4 MiB" in result_pos.output
 
 
 @pytest.mark.parametrize("grid_layout", ["-g", None])

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -3,7 +3,7 @@ import pytest
 from iohub._deprecated.singlepagetiff import MicromanagerSequenceReader
 from iohub.mmstack import MMStack
 from iohub.ndtiff import NDTiffDataset
-from iohub.reader import read_images
+from iohub.reader import read_images, sizeof_fmt
 from tests.conftest import (
     mm2gamma_ome_tiffs,
     mm2gamma_singlepage_tiffs,
@@ -36,3 +36,11 @@ def test_detect_ndtiff(data_path):
 def test_detect_single_page_tiff(data_path):
     reader = read_images(data_path)
     assert isinstance(reader, MicromanagerSequenceReader)
+
+
+@pytest.mark.parametrize(
+    "num_bytes,expected",
+    [(3, "3 B"), (2.234 * 2**20, "2.2 MiB"), (3.456 * 2**40, "3.5 TiB")],
+)
+def test_sizeof_fmt(num_bytes, expected):
+    assert sizeof_fmt(num_bytes) == expected


### PR DESCRIPTION
This addresses issue #247 by adding the store size and array size in GB. This is useful and simple metadata. 

I wanted to know how much memory to request for caching datasets.