### PR TITLE
Fixing tests for process_single_position_setup()

### DIFF
--- a/tests/ngff/test_ngff_utils.py
+++ b/tests/ngff/test_ngff_utils.py
@@ -303,6 +303,9 @@ def process_single_position_setup(draw):
     position_keys, channel_names, shape, chunks, scale, dtype = draw(
         plate_setup()
     )
+    # NOTE: Chunking along T,C =1,1
+    if chunks is not None:
+        chunks = (1, 1) + chunks[2:]
 
     T, C = shape[:2]
 


### PR DESCRIPTION
Fixing process_single_position_setup() to pass tests. The chunks should be (1,1,Z,Y,X) since we parallelize over T, C.



