### PR TITLE
ImageArray Initialization

### DIFF
--- a/iohub/ngff/nodes.py
+++ b/iohub/ngff/nodes.py
@@ -312,7 +312,8 @@ class ImageArray(zarr.Array):
 
     def __init__(self, zarray: zarr.Array = None, **kwargs):
         """Keyword arguments are passed to the zarr.Array constructor.
-        If a zarr.Array is provided, the constructor will use its attributes.
+        If a zarr.Array is provided, the constructor will use its attributes
+        to initialize the ImageArray.
         """
         if zarray is not None:
             kwargs.update(

--- a/iohub/ngff/nodes.py
+++ b/iohub/ngff/nodes.py
@@ -310,20 +310,24 @@ class NGFFNode:
 class ImageArray(zarr.Array):
     """Container object for image stored as a zarr array (up to 5D)"""
 
-    def __init__(self, zarray: zarr.Array):
-        super().__init__(
-            store=zarray._store,
-            path=zarray._path,
-            read_only=zarray._read_only,
-            chunk_store=zarray._chunk_store,
-            synchronizer=zarray._synchronizer,
-            cache_metadata=zarray._cache_metadata,
-            cache_attrs=zarray._attrs.cache,
-            partial_decompress=zarray._partial_decompress,
-            write_empty_chunks=zarray._write_empty_chunks,
-            zarr_version=zarray._version,
-            meta_array=zarray._meta_array,
-        )
+    def __init__(self, zarray: zarr.Array = None, **kwargs):
+        if zarray is not None:
+            kwargs.update(
+                {
+                    "store": zarray._store,
+                    "path": zarray._path,
+                    "read_only": zarray._read_only,
+                    "chunk_store": zarray._chunk_store,
+                    "synchronizer": zarray._synchronizer,
+                    "cache_metadata": zarray._cache_metadata,
+                    "cache_attrs": zarray._attrs.cache,
+                    "partial_decompress": zarray._partial_decompress,
+                    "write_empty_chunks": zarray._write_empty_chunks,
+                    "zarr_version": zarray._version,
+                    "meta_array": zarray._meta_array,
+                }
+            )
+        super().__init__(**kwargs)
         self._get_dims()
 
     def _get_dims(self):

--- a/iohub/ngff/nodes.py
+++ b/iohub/ngff/nodes.py
@@ -311,6 +311,9 @@ class ImageArray(zarr.Array):
     """Container object for image stored as a zarr array (up to 5D)"""
 
     def __init__(self, zarray: zarr.Array = None, **kwargs):
+        """Keyword arguments are passed to the zarr.Array constructor.
+        If a zarr.Array is provided, the constructor will use its attributes.
+        """
         if zarray is not None:
             kwargs.update(
                 {


### PR DESCRIPTION
`ImageArray` is designed to be initialized with a zarr array. This causes problems when using ImageArrays in parallel compute using dask, where arrays are initialized using key-value arguments, as in https://zarr.readthedocs.io/en/stable/_modules/zarr/core.html#Array. Here is a minimal example

```python
import dask.array as da
from iohub import open_ome_zarr
from multiprocessing import Pool

data_path = path_to_data  # path to any zarr store

with open_ome_zarr(data_path) as ds:
    data = da.from_zarr(ds.data)

func = sum  # you favorite funciton

with Pool(2) as p:
    output = p.map(func, data)
```

This example will fail, likely because of the way dask initializes the zarr arrays in the workers. In this PR, I make the zarray argument optional and allow for additional keyword arguments.

Fixed #226 