### PR TITLE
More robust calculation of "z-step_um" for ndtiff datasets

### DIFF
--- a/iohub/ndtiff.py
+++ b/iohub/ndtiff.py
@@ -140,19 +140,20 @@ class NDTiffDataset(MicroManagerFOVMapping):
         c_idx = self._ndtiff_channel_names[0]
         img_metadata = self.get_image_metadata(p_idx, 0, c_idx, 0)
 
-        pm_metadata["z-step_um"] = None
-        if "ZPosition_um_Intended" in img_metadata.keys():
+        try:
+            z0 = self.get_image_metadata(p_idx, 0, c_idx, 0)[
+                "ZPosition_um_Intended"
+            ]
+            z1 = self.get_image_metadata(p_idx, 0, c_idx, 1)[
+                "ZPosition_um_Intended"
+            ]
             pm_metadata["z-step_um"] = np.around(
-                abs(
-                    self.get_image_metadata(p_idx, 0, c_idx, 1)[
-                        "ZPosition_um_Intended"
-                    ]
-                    - self.get_image_metadata(p_idx, 0, c_idx, 0)[
-                        "ZPosition_um_Intended"
-                    ]
-                ),
-                decimals=3,
+                abs(z1 - z0), decimals=3
             ).astype(float)
+        # Will raise KeyError if dataset does not have z slices
+        # Will raise ValueError if dataset has only one z slice
+        except (KeyError, ValueError):
+            pm_metadata["z-step_um"] = None
 
         pm_metadata["StagePositions"] = []
         if "position" in self._axes:


### PR DESCRIPTION
The calculations of `z-step_um` fails if the dataset has only a single z slice. In that case, `ZPosition_um_Intended` exists in the metadata, but the dataset does not have images at `z_idx = 1`. Here I've wrapped the calculation of `z-step_um` in a try/except statement which would catch both cases.

@ahillsley please confirm that this PR fixes your issue and approve it.