### PR TITLE
Fix reading Dragonfly non-OpenCell datasets with incomplete metadata

### DIFF
--- a/iohub/mmstack.py
+++ b/iohub/mmstack.py
@@ -219,7 +219,7 @@ class MMStack(MicroManagerFOVMapping):
         # acquisition script on the Dragonfly miroscope
         elif (
             mm_version == "2.0.1 20220920"
-            and self._mm_meta["Summary"]["Prefix"] == "raw_data"
+            and self._mm_meta["Summary"].get("Prefix", None) == "raw_data"
         ):
             files = natsorted(self.root.glob("*.ome.tif"))
             self.positions = len(files)  # not all positions are saved

--- a/iohub/mmstack.py
+++ b/iohub/mmstack.py
@@ -238,7 +238,7 @@ class MMStack(MicroManagerFOVMapping):
                 self.channel_names.append(ch)
 
         else:
-            if self._mm_meta["Summary"].get("Positions", []) > 1:
+            if self._mm_meta["Summary"].get("Positions", 1) > 1:
                 self._stage_positions = []
 
                 for p in range(self._mm_meta["Summary"]["Positions"]):

--- a/iohub/mmstack.py
+++ b/iohub/mmstack.py
@@ -238,7 +238,7 @@ class MMStack(MicroManagerFOVMapping):
                 self.channel_names.append(ch)
 
         else:
-            if self._mm_meta["Summary"]["Positions"] > 1:
+            if self._mm_meta["Summary"].get("Positions", []) > 1:
                 self._stage_positions = []
 
                 for p in range(self._mm_meta["Summary"]["Positions"]):


### PR DESCRIPTION
Use empty defaults when position, channel, and prefix metadata is not available.

Seems to fix https://github.com/czbiohub-sf/iohub/issues/267.