### PR TITLE
Support metadata for `.zarr` converted from `.nd2` using `bioformats2raw` conversion

### DIFF
--- a/iohub/ngff/models.py
+++ b/iohub/ngff/models.py
@@ -287,7 +287,7 @@ class RDefsMeta(MetaBase):
 class OMEROMeta(VersionMeta):
     """https://ngff.openmicroscopy.org/0.4/index.html#omero-md"""
 
-    id: int
+    id: int | None = None
     name: str | None = None
     channels: list[ChannelMeta] | None = None
     rdefs: RDefsMeta | None = None

--- a/iohub/ngff/models.py
+++ b/iohub/ngff/models.py
@@ -166,7 +166,7 @@ class TimeAxisMeta(NamedAxisMeta):
             "zettasecond",
         ]
         | None
-    )
+    ) = None
 
 
 """https://ngff.openmicroscopy.org/0.4/index.html#axes-md"""

--- a/iohub/ngff/models.py
+++ b/iohub/ngff/models.py
@@ -134,7 +134,7 @@ class SpaceAxisMeta(NamedAxisMeta):
             "zettameter",
         ]
         | None
-    )
+    ) = None
 
 
 class TimeAxisMeta(NamedAxisMeta):

--- a/iohub/reader.py
+++ b/iohub/reader.py
@@ -25,9 +25,12 @@ _logger = logging.getLogger(__name__)
 
 
 def _find_ngff_version_in_zarr_group(group: zarr.Group):
-    for key in ["omero", "plate", "well"]:
+    for key in ["multiscales", "omero", "plate", "well"]:
         if key in group.attrs:
-            return group.attrs[key].get("version")
+            if key == "multiscales":
+                return group.attrs[key][0].get("version")
+            else:
+                return group.attrs[key].get("version")
 
 
 def _check_zarr_data_type(src: Path):


### PR DESCRIPTION
This PR contains minor spec-mismatch bug fixes to enable `iohub info` to work with `.zarr` files converted from `.nd2` using [`bioformats2raw` conversion tool](https://github.com/glencoesoftware/bioformats2raw?tab=readme-ov-file#usage). 

For example:
```
iohub info /hpc/projects/comp.micro/zebrafish-macrophage/2025-02-15-93a 4dpf/250215_93a_4dpf_em2_sib_2048_002.zarr/0
```
prints
```
Reading file:	 /hpc/projects/comp.micro/zebrafish-macrophage/2025-02-15-93a-4dpf/250215_93a_4dpf_em2_sib_2048_002.zarr/0
Zarr hierarchy:
/
 ├── 0 (10, 3, 66, 2048, 2048) >u2
 ├── 1 (10, 3, 66, 1024, 1024) >u2
 ├── 2 (10, 3, 66, 512, 512) >u2
 └── 3 (10, 3, 66, 256, 256) >u2

=== Summary ===
Format:			 omezarr v0.4
Axes:			 t (time); c (channel); z (space); y (space); x (space); 
Channel names:		 ['DIA', 'GFP', 'RFP']
(Z, Y, X) scale (um):	 (1.0, 0.157177107973598, 0.157177107973598)
Chunk size:		 (1, 1, 1, 1024, 1024)
No. bytes decompressed:		 16609443840 [15.5 GiB]
```

Note: `bioformats2raw` seems to create single positions stacked one layer deeper than our typical single positions, so I call `iohub info` on `.zarr/0`.   

Note: @ziw-liu @mattersoflight I'm tagging you here to keep you in the loop. I'll plan to request your review after we've completed a phase reconstruction during the week of March 3.   