### PR TITLE
Use sphinx-polyversion

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup Pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,15 +37,14 @@ jobs:
           REPO_NAME="${GITHUB_REPOSITORY#*/}"
           echo "GITHUB_PAGES_URL=https://$REPO_OWNER.github.io/$REPO_NAME" >> $GITHUB_ENV
       - name: Build the docs
-        working-directory: ./docs
         run: |
           echo $GITHUB_PAGES_URL
-          make publish
-          touch build/html/.nojekyll
+          make publish -C docs
+          touch docs/build/html/.nojekyll
       - name: Upload build artifacts
         uses: actions/upload-pages-artifact@v1
         with:
-          path: "./docs/build/html"
+          path: "./docs/build"
 
   deploy:
     environment:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Checkout main
+        run: |
+          git fetch origin main:main
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Checkout main
+      - name: Fetch main
         run: |
           git fetch origin main:main
           git status

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build the docs
         run: |
           echo $GITHUB_PAGES_URL
-          make publish -C docs
+          make build -C docs
           touch docs/build/.nojekyll
       - name: Upload build artifacts
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Checkout main
         run: |
           git fetch origin main:main
+          git status
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,7 +44,7 @@ jobs:
           make publish -C docs
           touch docs/build/.nojekyll
       - name: Upload build artifacts
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: "./docs/build"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,6 +31,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install ".[doc]"
+          # temporary fix for sphinx-polyversion
+          pip install --force-reinstall git+https://github.com/ziw-liu/sphinx-polyversion.git@iohub-staging
       - name: Set environment
         run: |
           REPO_OWNER="${GITHUB_REPOSITORY%%/*}"
@@ -40,7 +42,7 @@ jobs:
         run: |
           echo $GITHUB_PAGES_URL
           make publish -C docs
-          touch docs/build/html/.nojekyll
+          touch docs/build/.nojekyll
       - name: Upload build artifacts
         uses: actions/upload-pages-artifact@v1
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -118,6 +118,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install ".[doc]"
+          # temporary fix for sphinx-polyversion
+          pip install --force-reinstall git+https://github.com/ziw-liu/sphinx-polyversion.git@iohub-staging
 
       - name: Test docs build
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -121,4 +121,4 @@ jobs:
 
       - name: Test docs build
         run: |
-          sphinx-polyversion docs/poly.py -vv
+          make build -C docs

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ["3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -41,7 +41,7 @@ jobs:
         python-version: ["3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -64,7 +64,7 @@ jobs:
         python-version: ["3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -85,7 +85,7 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v4
         with:
@@ -108,7 +108,7 @@ jobs:
     needs: [style, lint, isort]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v4
         with:
@@ -123,4 +123,4 @@ jobs:
 
       - name: Test docs build
         run: |
-          make build -C docs
+          sphinx-polyversion docs/poly.py -vvv --local

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -120,6 +120,5 @@ jobs:
           pip install ".[doc]"
 
       - name: Test docs build
-        working-directory: ./docs
         run: |
-          make build
+          sphinx-polyversion docs/poly.py -vv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         platform: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v4
         with:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,6 +1,5 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
 BUILDDIR      = build
 
 # Internal variables.
@@ -28,12 +27,7 @@ clean:
 	-rm -rf source/auto_examples/*
 
 build:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	-sphinx-polyversion poly.py $(BUILDDIR) -vvv
+	-cp gh-pages-redirect.html $(BUILDDIR)/index.html
 	@echo
-	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
-
-publish:
-	sphinx-multiversion source build/html
-	cp gh-pages-redirect.html build/html/index.html
-	@echo
-	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)."

--- a/docs/poly.py
+++ b/docs/poly.py
@@ -30,9 +30,6 @@ SOURCE_DIR = "docs/"
 #: Arguments to pass to `pip install`
 PIP_ARGS = [".[doc]"]
 
-#: Arguments to pass to `sphinx-build`
-SPHINX_ARGS = ["-D", "plot_gallery=0"]
-
 #: Mock data used for building local version
 MOCK_DATA = {
     "revisions": [
@@ -53,6 +50,16 @@ MOCK_DATA = {
     ),
 }
 
+#: Whether to build using only local files and mock data
+MOCK = False
+
+# Load overrides read from commandline to global scope
+apply_overrides(globals())
+# Determine repository root directory
+root = Git.root(Path(__file__).parent)
+
+# Setup driver and run it
+src = Path(SOURCE_DIR)
 ENVIRONMENT = {
     "v0.1.0": Pip.factory(
         venv=Path(".venv"),
@@ -66,16 +73,11 @@ ENVIRONMENT = {
     ),
 }
 
-#: Whether to build using only local files and mock data
-MOCK = False
+BUILDER = {
+    "v0.1.0": SphinxBuilder(src / "source", args=["-D", "plot_gallery=0"]),
+    "main": SphinxBuilder(src / "source", args=[]),
+}
 
-# Load overrides read from commandline to global scope
-apply_overrides(globals())
-# Determine repository root directory
-root = Git.root(Path(__file__).parent)
-
-# Setup driver and run it
-src = Path(SOURCE_DIR)
 DefaultDriver(
     root,
     OUTPUT_DIR,
@@ -85,7 +87,7 @@ DefaultDriver(
         buffer_size=1 * 10**9,  # 1 GB
         predicate=file_predicate([src]),  # exclude refs without source dir
     ),
-    builder=SphinxBuilder(src / "source", args=SPHINX_ARGS),
+    builder=BUILDER,
     env=ENVIRONMENT,
     # template_dir=root / src / "templates",
     static_dir=root / src / "source" / "_static",

--- a/docs/poly.py
+++ b/docs/poly.py
@@ -1,0 +1,77 @@
+from datetime import datetime
+from pathlib import Path
+
+from sphinx_polyversion import apply_overrides
+from sphinx_polyversion.driver import DefaultDriver
+from sphinx_polyversion.git import Git, GitRef, GitRefType, file_predicate
+from sphinx_polyversion.pyvenv import Pip, VenvWrapper
+from sphinx_polyversion.sphinx import SphinxBuilder
+
+#: Regex matching the branches to build docs for
+BRANCH_REGEX = r"^main$"
+
+#: Regex matching the tags to build docs for
+TAG_REGEX = r"^v\d+\.\d+\.\d+$"
+
+#: Output dir relative to project root
+#: !!! This name has to be choosen !!!
+OUTPUT_DIR = "docs/build"
+
+#: Source directory
+SOURCE_DIR = "docs/"
+
+#: Arguments to pass to `pip install`
+PIP_ARGS = ["."]
+
+#: Arguments to pass to `sphinx-build`
+SPHINX_ARGS = []
+
+#: Mock data used for building local version
+MOCK_DATA = {
+    "revisions": [
+        GitRef(
+            name="v0.1.0",
+            obj="",
+            ref="",
+            type_=GitRefType.TAG,
+            date=datetime(year=2024, month=2, day=13),
+        )
+    ],
+    "current": GitRef(
+        name="local",
+        obj="",
+        ref="",
+        type_=GitRefType.BRANCH,
+        date=datetime.now(),
+    ),
+}
+
+#: Whether to build using only local files and mock data
+MOCK = False
+
+# Load overrides read from commandline to global scope
+apply_overrides(globals())
+# Determine repository root directory
+root = Git.root(Path(__file__).parent)
+
+# Setup driver and run it
+src = Path(SOURCE_DIR)
+DefaultDriver(
+    root,
+    OUTPUT_DIR,
+    vcs=Git(
+        branch_regex=r"polyversion",
+        tag_regex=r"",
+        buffer_size=1 * 10**9,  # 1 GB
+        predicate=file_predicate([src]),  # exclude refs without source dir
+    ),
+    builder=SphinxBuilder(src / "source", args=SPHINX_ARGS),
+    env=Pip.factory(
+        venv=Path(".venv"),
+        args=PIP_ARGS,
+        creator=VenvWrapper(),
+    ),
+    # template_dir=root / src / "templates",
+    static_dir=root / src / "source" / "_static",
+    mock=MOCK_DATA,
+).run()

--- a/docs/poly.py
+++ b/docs/poly.py
@@ -60,30 +60,42 @@ root = Git.root(Path(__file__).parent)
 
 # Setup driver and run it
 src = Path(SOURCE_DIR)
-ENVIRONMENT = {
-    "v0.1.0": Pip.factory(
-        venv=Path(".venv") / "v0.1.0",
-        args=PIP_ARGS
-        + [
-            "sphinxcontrib-applehelp<=1.0.4",
-            "sphinxcontrib-devhelp<=1.0.2",
-            "sphinxcontrib-htmlhelp<=2.0.1",
-            "sphinxcontrib-qthelp<=1.0.3",
-            "sphinxcontrib-serializinghtml<=1.1.5",
-        ],
-        creator=VenvWrapper(),
-    ),
-    "main": Pip.factory(
-        venv=Path(".venv") / "main",
+ENVIRONMENT = (
+    {
+        "v0.1.0": Pip.factory(
+            venv=Path(".venv") / "v0.1.0",
+            args=PIP_ARGS
+            + [
+                "sphinxcontrib-applehelp<=1.0.4",
+                "sphinxcontrib-devhelp<=1.0.2",
+                "sphinxcontrib-htmlhelp<=2.0.1",
+                "sphinxcontrib-qthelp<=1.0.3",
+                "sphinxcontrib-serializinghtml<=1.1.5",
+            ],
+            creator=VenvWrapper(),
+        ),
+        "main": Pip.factory(
+            venv=Path(".venv") / "main",
+            args=PIP_ARGS + ["importlib_metadata"],
+            creator=VenvWrapper(),
+        ),
+    }
+    if not MOCK
+    else Pip.factory(
+        venv=Path(".venv") / "local",
         args=PIP_ARGS + ["importlib_metadata"],
         creator=VenvWrapper(),
-    ),
-}
+    )
+)
 
-BUILDER = {
-    "v0.1.0": SphinxBuilder(src / "source", args=["-D", "plot_gallery=0"]),
-    "main": SphinxBuilder(src / "source", args=[]),
-}
+BUILDER = (
+    {
+        "v0.1.0": SphinxBuilder(src / "source", args=["-D", "plot_gallery=0"]),
+        "main": SphinxBuilder(src / "source", args=[]),
+    }
+    if not MOCK
+    else SphinxBuilder(src / "source", args=[])
+)
 
 DefaultDriver(
     root,
@@ -100,4 +112,4 @@ DefaultDriver(
     static_dir=root / src / "source" / "_static",
     mock=MOCK_DATA,
     selector=partial(closest_tag, root),
-).run()
+).run(MOCK)

--- a/docs/poly.py
+++ b/docs/poly.py
@@ -62,7 +62,7 @@ root = Git.root(Path(__file__).parent)
 src = Path(SOURCE_DIR)
 ENVIRONMENT = {
     "v0.1.0": Pip.factory(
-        venv=Path(".venv"),
+        venv=Path(".venv") / "v0.1.0",
         args=PIP_ARGS
         + [
             "sphinxcontrib-applehelp<=1.0.4",
@@ -74,8 +74,8 @@ ENVIRONMENT = {
         creator=VenvWrapper(),
     ),
     "main": Pip.factory(
-        venv=Path(".venv"),
-        args=PIP_ARGS,
+        venv=Path(".venv") / "main",
+        args=PIP_ARGS + ["importlib_metadata"],
         creator=VenvWrapper(),
     ),
 }

--- a/docs/poly.py
+++ b/docs/poly.py
@@ -62,6 +62,11 @@ root = Git.root(Path(__file__).parent)
 src = Path(SOURCE_DIR)
 ENVIRONMENT = (
     {
+        None: Pip.factory(
+            venv=Path(".venv") / "default",
+            args=PIP_ARGS,
+            creator=VenvWrapper(),
+        ),
         "v0.1.0": Pip.factory(
             venv=Path(".venv") / "v0.1.0",
             args=PIP_ARGS
@@ -90,6 +95,7 @@ ENVIRONMENT = (
 
 BUILDER = (
     {
+        None: SphinxBuilder(src / "source", args=[]),
         "v0.1.0": SphinxBuilder(src / "source", args=["-D", "plot_gallery=0"]),
         "main": SphinxBuilder(src / "source", args=[]),
     }

--- a/docs/poly.py
+++ b/docs/poly.py
@@ -63,7 +63,14 @@ src = Path(SOURCE_DIR)
 ENVIRONMENT = {
     "v0.1.0": Pip.factory(
         venv=Path(".venv"),
-        args=PIP_ARGS,
+        args=PIP_ARGS
+        + [
+            "sphinxcontrib-applehelp<=1.0.4",
+            "sphinxcontrib-devhelp<=1.0.2",
+            "sphinxcontrib-htmlhelp<=2.0.1",
+            "sphinxcontrib-qthelp<=1.0.3",
+            "sphinxcontrib-serializinghtml<=1.1.5",
+        ],
         creator=VenvWrapper(),
     ),
     "main": Pip.factory(

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,7 +8,9 @@ import os
 import sys
 
 import importlib_metadata
+from sphinx_polyversion import load_globals
 
+load_globals(globals())
 # -- General configuration ----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,11 +52,6 @@ numpydoc_show_class_members = True
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ["_templates"]
 
-# Disabling generation of docs on different branches to use tags only
-# smv_tag_whitelist = r"^v\d+\.\d+\.\d+$"
-# smv_branch_whitelist = r"^main$"
-# smv_latest_version = r"^main$"
-
 # The suffix of source filenames.
 source_suffix = ".rst"
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,7 +35,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx_copybutton",
     "numpydoc",
-    "sphinx_multiversion",
+    "sphinx_polyversion",
     "sphinx_sitemap",
     "sphinx_gallery.gen_gallery",
 ]
@@ -53,9 +53,9 @@ numpydoc_show_class_members = True
 # templates_path = ["_templates"]
 
 # Disabling generation of docs on different branches to use tags only
-smv_tag_whitelist = r"^v\d+\.\d+\.\d+$"
-smv_branch_whitelist = r"^main$"
-smv_latest_version = r"^main$"
+# smv_tag_whitelist = r"^v\d+\.\d+\.\d+$"
+# smv_branch_whitelist = r"^main$"
+# smv_latest_version = r"^main$"
 
 # The suffix of source filenames.
 source_suffix = ".rst"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,9 +8,9 @@ import os
 import sys
 
 import importlib_metadata
-from sphinx_polyversion import load_globals
+from sphinx_polyversion import load
 
-load_globals(globals())
+load(globals())
 # -- General configuration ----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/iohub/convert.py
+++ b/iohub/convert.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from importlib.metadata import version
 from pathlib import Path
 from typing import Literal
 
@@ -9,7 +10,6 @@ from tqdm import tqdm
 from tqdm.contrib.itertools import product
 from tqdm.contrib.logging import logging_redirect_tqdm
 
-from iohub._version import version as iohub_version
 from iohub.ngff.models import TransformationMeta
 from iohub.ngff.nodes import Position, open_ome_zarr
 from iohub.reader import MMStack, NDTiffDataset, read_images
@@ -140,7 +140,7 @@ class TIFFConverter:
             f"dimensions (P, T, C, Z, Y, X): {self.dim}"
         )
         self.metadata = dict()
-        self.metadata["iohub_version"] = iohub_version
+        self.metadata["iohub_version"] = version("iohub")
         self.metadata["Summary"] = self.summary_metadata
         if grid_layout:
             if hcs_plate:

--- a/iohub/ngff/__init__.py
+++ b/iohub/ngff/__init__.py
@@ -1,10 +1,21 @@
 from iohub.ngff.models import TransformationMeta
-from iohub.ngff.nodes import ImageArray, Plate, Position, open_ome_zarr
+from iohub.ngff.nodes import (
+    ImageArray,
+    NGFFNode,
+    Plate,
+    Position,
+    TiledImageArray,
+    TiledPosition,
+    open_ome_zarr,
+)
 
 __all__ = [
     "ImageArray",
-    "open_ome_zarr",
+    "NGFFNode",
     "Plate",
     "Position",
+    "TiledImageArray",
+    "TiledPosition",
     "TransformationMeta",
+    "open_ome_zarr",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,6 @@ doc =
     sphinx>=4.2.0
     pydata-sphinx-theme>=0.15.2
     sphinx-copybutton>=0.4.0
-    sphinx-multiversion>=0.2.4
+    sphinx-polyversion>=0.2.4
     sphinx-sitemap>=2.5.0
     sphinx-gallery>=0.13.0


### PR DESCRIPTION
Use sphinx-polyversion to create a different virtual environment when building documentation for each version. This allows documentation to be built simultaneously for versions that have incompatible dependencies.

~(Not working yet)~

Example build: https://github.com/czbiohub-sf/iohub/actions/runs/14072556212/job/39409605319 (the files can be downloaded from the 'upload artifact' step). This PR says 'failure' because the deployment step is not allowed before merging.