### PR TITLE
Compare MM FOVs

### DIFF
--- a/iohub/mm_fov.py
+++ b/iohub/mm_fov.py
@@ -24,7 +24,7 @@ class MicroManagerFOV(BaseFOV):
     def __eq__(self, other: BaseFOV) -> bool:
         if not isinstance(other, type(self)):
             return False
-        return (self.position == other.position) and (
+        return (self._position == other._position) and (
             self.root.absolute() == other.root.absolute()
         )
 

--- a/iohub/mm_fov.py
+++ b/iohub/mm_fov.py
@@ -21,6 +21,13 @@ class MicroManagerFOV(BaseFOV):
             f"Data:\n"
         ) + self.xdata.__repr__()
 
+    def __eq__(self, other: BaseFOV) -> bool:
+        if not isinstance(other, type(self)):
+            return False
+        return (self.position == other.position) and (
+            self.root.absolute() == other.root.absolute()
+        )
+
     @property
     def parent(self) -> MicroManagerFOVMapping:
         return self._parent

--- a/tests/mmstack/test_mmstack.py
+++ b/tests/mmstack/test_mmstack.py
@@ -92,3 +92,12 @@ def test_fov_getitem(ome_tiff):
         for ch in fov.channel_names:
             assert img.sel(T=0, Z=0, C=ch, Y=0, X=0) >= 0
     mmstack.close()
+
+
+def test_fov_equal(ome_tiff):
+    ref1 = MMStack(ome_tiff)
+    ref2 = MMStack(ome_tiff)
+    for (_, fov1), (_, fov2) in zip(ref1, ref2):
+        assert fov1 == fov2
+    ref1.close()
+    ref2.close()

--- a/tests/mmstack/test_mmstack.py
+++ b/tests/mmstack/test_mmstack.py
@@ -101,3 +101,11 @@ def test_fov_equal(ome_tiff):
         assert fov1 == fov2
     ref1.close()
     ref2.close()
+
+
+def test_fov_not_equal(ome_tiff):
+    with MMStack(ome_tiff) as mmstack:
+        if len(mmstack) < 2:
+            # pass
+            return
+        assert mmstack["0"] != mmstack["1"]


### PR DESCRIPTION
Make MM FOVs special cases when comparing, since they do not have individual paths.

Resolve #157.