### PR TITLE
Check overwrite path

### DIFF
--- a/iohub/ngff/nodes.py
+++ b/iohub/ngff/nodes.py
@@ -5,11 +5,11 @@ Node object and convenience functions for the OME-NGFF (OME-Zarr) Hierarchy.
 # TODO: remove this in the future (PEP deferred for 3.11, now 3.12?)
 from __future__ import annotations
 
-from pathlib import Path
 import logging
 import math
 import os
 from copy import deepcopy
+from pathlib import Path
 from typing import TYPE_CHECKING, Generator, Literal, Sequence, Type
 
 import numpy as np

--- a/iohub/ngff/nodes.py
+++ b/iohub/ngff/nodes.py
@@ -5,6 +5,7 @@ Node object and convenience functions for the OME-NGFF (OME-Zarr) Hierarchy.
 # TODO: remove this in the future (PEP deferred for 3.11, now 3.12?)
 from __future__ import annotations
 
+from pathlib import Path
 import logging
 import math
 import os
@@ -1804,20 +1805,21 @@ class Plate(NGFFNode):
 
 
 def open_ome_zarr(
-    store_path: StrOrBytesPath,
+    store_path: StrOrBytesPath | Path,
     layout: Literal["auto", "fov", "hcs", "tiled"] = "auto",
     mode: Literal["r", "r+", "a", "w", "w-"] = "r",
     channel_names: list[str] | None = None,
     axes: list[AxisMeta] | None = None,
     version: Literal["0.1", "0.4"] = "0.4",
     synchronizer: zarr.ThreadSynchronizer | zarr.ProcessSynchronizer = None,
+    disable_path_checking: bool = False,
     **kwargs,
 ) -> Plate | Position | TiledPosition:
     """Convenience method to open OME-Zarr stores.
 
     Parameters
     ----------
-    store_path : StrOrBytesPath
+    store_path : StrOrBytesPath | Path
         File path to the Zarr store to open
     layout: Literal["auto", "fov", "hcs", "tiled"], optional
         NGFF store layout:
@@ -1855,6 +1857,14 @@ def open_ome_zarr(
         OME-NGFF version, by default "0.4"
     synchronizer : object, optional
         Zarr thread or process synchronizer, by default None
+    disable_path_checking : bool, optional
+        Whether to allow overwriting a path that does not contain '.zarr',
+        by default False
+
+        .. warning::
+            This can lead to severe data loss
+            if the input path is not checked carefully.
+
     kwargs : dict, optional
         Keyword arguments to underlying NGFF node constructor,
         by default None
@@ -1868,16 +1878,26 @@ def open_ome_zarr(
         :py:class:`iohub.ngff.Plate`,
         or :py:class:`iohub.ngff.TiledPosition`)
     """
+    store_path = Path(store_path)
     if mode == "a":
-        mode = ("w-", "r+")[int(os.path.exists(store_path))]
+        mode = ("w-", "r+")[int(store_path.exists())]
     parse_meta = False
     if mode in ("r", "r+"):
         parse_meta = True
     elif mode == "w-":
-        if os.path.exists(store_path):
+        if store_path.exists():
             raise FileExistsError(store_path)
     elif mode == "w":
-        if os.path.exists(store_path):
+        if store_path.exists():
+            if (
+                ".zarr" not in str(store_path.resolve())
+                and not disable_path_checking
+            ):
+                raise ValueError(
+                    "Cannot overwrite a path that does not contain '.zarr', "
+                    "use `disable_path_checking=True` if you are sure that "
+                    f"{store_path} should be overwritten."
+                )
             _logger.warning(f"Overwriting data at {store_path}")
     else:
         raise ValueError(f"Invalid persistence mode '{mode}'.")

--- a/tests/ngff/test_ngff.py
+++ b/tests/ngff/test_ngff.py
@@ -124,10 +124,11 @@ def test_open_store_create_existing():
     """Test `iohub.ngff._open_store()"""
     with TemporaryDirectory() as temp_dir:
         store_path = os.path.join(temp_dir, "new.zarr")
-        g = zarr.open_group(store_path, mode="w")
+        g = zarr.open_group(store_path, mode="w-")
         g.store.close()
         with pytest.raises(RuntimeError):
             _ = _open_store(store_path, mode="w-", version="0.4")
+        assert _open_store(store_path, mode="w", version="0.4") is not None
 
 
 def test_open_store_read_nonexist():
@@ -150,6 +151,34 @@ def test_init_ome_zarr(channel_names):
         )
         assert os.path.isdir(store_path)
         assert dataset.channel_names == channel_names
+
+
+@pytest.mark.parametrize(
+    "basename", ["some.zarr", "random_dir", "napari_ome_zarr"]
+)
+def test_init_ome_zarr_overwrite_non_zarr(tmp_path, basename):
+    """Test `iohub.ngff.open_ome_zarr()`"""
+    store_path = tmp_path / basename
+    store_path.mkdir()
+    some_child_directory = store_path / "some_other_directory"
+    some_child_directory.mkdir()
+    if ".zarr" not in basename:
+        with pytest.raises(ValueError):
+            _ = open_ome_zarr(
+                store_path, layout="fov", mode="w", channel_names=["channel"]
+            )
+        assert some_child_directory.exists()
+    assert (
+        open_ome_zarr(
+            store_path,
+            layout="fov",
+            mode="w",
+            channel_names=["channel"],
+            disable_path_checking=True,
+        )
+        is not None
+    )
+    assert not some_child_directory.exists()
 
 
 @contextmanager

--- a/tests/ngff/test_ngff.py
+++ b/tests/ngff/test_ngff.py
@@ -154,12 +154,13 @@ def test_init_ome_zarr(channel_names):
 
 
 @pytest.mark.parametrize(
-    "basename", ["some.zarr", "random_dir", "napari_ome_zarr"]
+    "basename",
+    ["some.zarr", "other.zarr/0/0/0", "random_dir", "napari_ome_zarr"],
 )
 def test_init_ome_zarr_overwrite_non_zarr(tmp_path, basename):
     """Test `iohub.ngff.open_ome_zarr()`"""
     store_path = tmp_path / basename
-    store_path.mkdir()
+    store_path.mkdir(parents=True)
     some_child_directory = store_path / "some_other_directory"
     some_child_directory.mkdir()
     if ".zarr" not in basename:


### PR DESCRIPTION
Implement https://github.com/mehta-lab/waveorder/issues/439#issuecomment-2706996852.

By default, disallow overwriting paths that do not contain `.zarr` to reduce data loss incidents caused by erroneous user input.

This can be disabled to restore spec conformance.