### PR TITLE
Remove fetching step in build docs action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,10 +24,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Fetch main
-        run: |
-          git fetch origin main:main
-          git status
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v3


### PR DESCRIPTION
Remove the fetching step since the action already runs run the main branch.