### PR TITLE
Handle case-insensitive platforms in Zarr hierarchy

### DIFF
--- a/iohub/ngff/nodes.py
+++ b/iohub/ngff/nodes.py
@@ -128,6 +128,7 @@ class NGFFNode:
             self._parse_meta()
         if not hasattr(self, "axes"):
             self.axes = self._DEFAULT_AXES
+        self._case_insensitive_fs = _case_insensitive_fs()
 
     @property
     def zgroup(self):
@@ -201,7 +202,18 @@ class NGFFNode:
 
     def __contains__(self, key):
         key = normalize_storage_path(key)
-        return key.lower() in [name.lower() for name in self._member_names]
+        if not self._case_insensitive_fs:
+            return key in self._member_names
+        for name in self._member_names:
+            if key.lower() != name.lower():
+                continue
+            if key != name:
+                _logger.warning(
+                    f"Key '{key}' matched member '{name}'. "
+                    "This may not work on case-sensitive filesystems."
+                )
+            return True
+        return False
 
     def __iter__(self):
         yield from self._member_names

--- a/iohub/ngff/nodes.py
+++ b/iohub/ngff/nodes.py
@@ -89,8 +89,8 @@ def _scale_integers(values: Sequence[int], factor: int) -> tuple[int, ...]:
     return tuple(int(math.ceil(v / factor)) for v in values)
 
 
-def _case_insensitive_fs() -> bool:
-    """Check if the filesystem is case-insensitive."""
+def _case_insensitive_local_fs() -> bool:
+    """Check if the local filesystem is case-insensitive."""
     return Path(__file__.lower()).exists() and Path(__file__.upper()).exists()
 
 
@@ -128,7 +128,9 @@ class NGFFNode:
             self._parse_meta()
         if not hasattr(self, "axes"):
             self.axes = self._DEFAULT_AXES
-        self._case_insensitive_fs = _case_insensitive_fs()
+        # TODO: properly check the underlying storage type
+        # This works for now as only the local filesystem is supported
+        self._case_insensitive_fs = _case_insensitive_local_fs()
 
     @property
     def zgroup(self):

--- a/iohub/ngff/nodes.py
+++ b/iohub/ngff/nodes.py
@@ -89,6 +89,11 @@ def _scale_integers(values: Sequence[int], factor: int) -> tuple[int, ...]:
     return tuple(int(math.ceil(v / factor)) for v in values)
 
 
+def _case_insensitive_fs() -> bool:
+    """Check if the filesystem is case-insensitive."""
+    return Path(__file__.lower()).exists() and Path(__file__.upper()).exists()
+
+
 class NGFFNode:
     """A node (group level in Zarr) in an NGFF dataset."""
 

--- a/iohub/ngff/nodes.py
+++ b/iohub/ngff/nodes.py
@@ -1698,6 +1698,11 @@ class Plate(NGFFNode):
         # normalize input
         row_name = normalize_storage_path(row_name)
         col_name = normalize_storage_path(col_name)
+        if row_name in self:
+            if col_name in self[row_name]:
+                raise FileExistsError(
+                    f"Well '{row_name}/{col_name}' already exists."
+                )
         row_meta = PlateAxisMeta(name=row_name)
         col_meta = PlateAxisMeta(name=col_name)
         row_index = self._auto_idx(row_name, row_index, "row")

--- a/tests/ngff/test_ngff.py
+++ b/tests/ngff/test_ngff.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import os
-import shutil
 import platform
+import shutil
 import string
 from contextlib import contextmanager
 from tempfile import TemporaryDirectory
@@ -23,11 +23,12 @@ if TYPE_CHECKING:
 
 from iohub.ngff.nodes import (
     TO_DICT_SETTINGS,
+    NGFFNode,
     Plate,
     TransformationMeta,
+    _case_insensitive_fs,
     _open_store,
     _pad_shape,
-    _case_insensitive_fs,
     open_ome_zarr,
 )
 from tests.conftest import hcs_ref
@@ -933,6 +934,18 @@ def test_get_axis_index():
 
         with pytest.raises(ValueError):
             _ = position.get_axis_index("DOG")
+
+
+def test_ngff_node_contains_cross_platform(caplog):
+    """Test `iohub.ngff.NGFFNode.__contains__()` on multiple platforms."""
+    with open_ome_zarr(hcs_ref, layout="hcs", mode="r") as dataset:
+        assert "B" in dataset
+        match platform.system():
+            case "Linux":
+                assert "b" not in dataset
+            case "Windows" | "Darwin":
+                assert "b" in dataset
+                assert any("Key 'b' matched" in r.message for r in caplog.records)
 
 
 @given(

--- a/tests/ngff/test_ngff.py
+++ b/tests/ngff/test_ngff.py
@@ -945,7 +945,9 @@ def test_ngff_node_contains_cross_platform(caplog):
                 assert "b" not in dataset
             case "Windows" | "Darwin":
                 assert "b" in dataset
-                assert any("Key 'b' matched" in r.message for r in caplog.records)
+                assert any(
+                    "Key 'b' matched" in r.message for r in caplog.records
+                )
 
 
 @given(
@@ -989,6 +991,21 @@ def test_create_well(row_names: list[str], col_names: list[str]):
         assert [
             r["name"] for r in dataset.zattrs["plate"]["rows"]
         ] == row_names
+
+
+def test_create_case_sensitive_well(tmp_path):
+    """Test `iohub.ngff.Plate.create_well()` with case-sensitive names."""
+    store_path = tmp_path / "hcs.zarr"
+    with open_ome_zarr(
+        store_path, layout="hcs", mode="w-", channel_names=["GFP"]
+    ) as dataset:
+        dataset.create_well("A", "B")
+        match platform.system():
+            case "Windows" | "Darwin":
+                with pytest.raises(FileExistsError):
+                    dataset.create_well("a", "b")
+            case "Linux":
+                dataset.create_well("a", "b")
 
 
 @given(

--- a/tests/ngff/test_ngff.py
+++ b/tests/ngff/test_ngff.py
@@ -161,6 +161,8 @@ def test_case_insensitive_fs():
             assert _case_insensitive_fs() is True
         case "Linux":
             assert _case_insensitive_fs() is False
+        case _:
+            _ = _case_insensitive_fs()
 
 
 @given(channel_names=channel_names_st)

--- a/tests/ngff/test_ngff.py
+++ b/tests/ngff/test_ngff.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import platform
 import string
 from contextlib import contextmanager
 from tempfile import TemporaryDirectory
@@ -26,6 +27,7 @@ from iohub.ngff.nodes import (
     TransformationMeta,
     _open_store,
     _pad_shape,
+    _case_insensitive_fs,
     open_ome_zarr,
 )
 from tests.conftest import hcs_ref
@@ -148,6 +150,17 @@ def test_open_store_read_nonexist():
             store_path = os.path.join(temp_dir, "new.zarr")
             with pytest.raises(FileNotFoundError):
                 _ = _open_store(store_path, mode=mode, version="0.4")
+
+
+def test_case_insensitive_fs():
+    """Test `iohub.ngff._case_insensitive_fs()`"""
+    match platform.system():
+        case "Windows":
+            assert _case_insensitive_fs() is True
+        case "Darwin":
+            assert _case_insensitive_fs() is True
+        case "Linux":
+            assert _case_insensitive_fs() is False
 
 
 @given(channel_names=channel_names_st)

--- a/tests/ngff/test_ngff.py
+++ b/tests/ngff/test_ngff.py
@@ -26,7 +26,7 @@ from iohub.ngff.nodes import (
     NGFFNode,
     Plate,
     TransformationMeta,
-    _case_insensitive_fs,
+    _case_insensitive_local_fs,
     _open_store,
     _pad_shape,
     open_ome_zarr,
@@ -153,17 +153,17 @@ def test_open_store_read_nonexist():
                 _ = _open_store(store_path, mode=mode, version="0.4")
 
 
-def test_case_insensitive_fs():
-    """Test `iohub.ngff._case_insensitive_fs()`"""
+def test_case_insensitive_local_fs():
+    """Test `iohub.ngff._case_insensitive_local_fs()`"""
     match platform.system():
         case "Windows":
-            assert _case_insensitive_fs() is True
+            assert _case_insensitive_local_fs() is True
         case "Darwin":
-            assert _case_insensitive_fs() is True
+            assert _case_insensitive_local_fs() is True
         case "Linux":
-            assert _case_insensitive_fs() is False
+            assert _case_insensitive_local_fs() is False
         case _:
-            _ = _case_insensitive_fs()
+            _ = _case_insensitive_local_fs()
 
 
 @given(channel_names=channel_names_st)


### PR DESCRIPTION
Fix #253.

Case coercing in key lookup only occurs when the platform requires it (i.e. not happening on Linux anymore).