### PR TITLE
Read MMStack with Zarr v3

### DIFF
--- a/iohub/_deprecated/zarrfile.py
+++ b/iohub/_deprecated/zarrfile.py
@@ -48,7 +48,7 @@ class ZarrReader(ReaderBase):
             raise ValueError(f"Invalid NGFF version: {version}")
         try:
             self.store = zarr.storage.LocalStore(store_path)
-            self.root = zarr.open(self.store, "r")
+            self.root = zarr.open(self.store, mode="r")
         except Exception:
             raise FileNotFoundError("Supplies path is not a valid zarr root")
         try:

--- a/iohub/convert.py
+++ b/iohub/convert.py
@@ -307,7 +307,9 @@ class TIFFConverter:
     def _init_grid_arrays(self, arr_kwargs):
         for row, columns in enumerate(self.position_grid):
             for column in columns:
-                self._create_zeros_array(str(row), column, "0", arr_kwargs)
+                self._create_zeros_array(
+                    str(row), str(column), "0", arr_kwargs
+                )
 
     def _create_zeros_array(
         self, row_name: str, col_name: str, pos_name: str, arr_kwargs: dict

--- a/iohub/mmstack.py
+++ b/iohub/mmstack.py
@@ -167,7 +167,6 @@ class MMStack(MicroManagerFOVMapping):
         xarr = img.expand_dims(
             [ax for ax in axes if ax not in img.dims]
         ).transpose(*axes)
-        self.dtype = xarr.dtype
         if self.channels > len(self.channel_names):
             for c in range(self.channels):
                 if c >= len(self.channel_names):

--- a/iohub/mmstack.py
+++ b/iohub/mmstack.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Iterable
 from warnings import catch_warnings, filterwarnings
 
-import xarray as xr
+import dask.array as da
 import fsspec
 import numpy as np
 import zarr
@@ -161,7 +161,9 @@ class MMStack(MicroManagerFOVMapping):
             zarr_tiff_store, root_uri=self._root.as_uri()
         )
         _logger.debug(f"Opened {self._store}.")
-        img = xr.open_zarr(self._store, consolidated=False)["0"]
+        data = da.from_zarr(zarr.open(self._store, mode="r")["0"])
+        self.dtype = data.dtype
+        img = DataArray(data, dims=raw_dims, name=self.dirname)
         xarr = img.expand_dims(
             [ax for ax in axes if ax not in img.dims]
         ).transpose(*axes)

--- a/iohub/mmstack.py
+++ b/iohub/mmstack.py
@@ -58,7 +58,7 @@ def _tiff_to_fsspec_store(
         "reference://",
         fo=json.loads(spec_container.getvalue()),
         target_protocol="file",
-        asynchronous=True
+        asynchronous=True,
     )
     return zarr.storage.FsspecStore(fs=fs)
 
@@ -165,6 +165,7 @@ class MMStack(MicroManagerFOVMapping):
         xarr = img.expand_dims(
             [ax for ax in axes if ax not in img.dims]
         ).transpose(*axes)
+        self.dtype = xarr.dtype
         if self.channels > len(self.channel_names):
             for c in range(self.channels):
                 if c >= len(self.channel_names):

--- a/iohub/mmstack.py
+++ b/iohub/mmstack.py
@@ -38,6 +38,20 @@ def _normalize_mm_pos_key(key: str | int) -> int:
 def _tiff_to_fsspec_store(
     zarr_tiff_store: ZarrTiffStore, root_uri: str
 ) -> zarr.storage.FsspecStore:
+    """Bridge tifffile (zarr-python v2 interface) with zarr-python v3.
+
+    Parameters
+    ----------
+    zarr_tiff_store : ZarrTiffStore
+        Zarr (v2) wrapper for a TIFF series
+    root_uri : str
+        `file://` URI to the directory containing the TIFF files
+
+    Returns
+    -------
+    zarr.storage.FsspecStore
+        Zarr (v3) wrapper for a TIFF series
+    """
     spec_container = io.StringIO()
     zarr_tiff_store.write_fsspec(spec_container, url=root_uri)
     fs, _ = fsspec.url_to_fs(

--- a/iohub/reader.py
+++ b/iohub/reader.py
@@ -32,7 +32,7 @@ def _find_ngff_version_in_zarr_group(group: zarr.Group):
 
 def _check_zarr_data_type(src: Path):
     try:
-        root = zarr.open(src, "r")
+        root = zarr.open(src, mode="r")
         if version := _find_ngff_version_in_zarr_group(root):
             return version
         else:

--- a/tests/_deprecated/test_singlepagetiff.py
+++ b/tests/_deprecated/test_singlepagetiff.py
@@ -63,7 +63,7 @@ def test_get_zarr(single_page_tiff):
     for i in range(mmr.get_num_positions()):
         z = mmr.get_zarr(i)
         assert z.shape == mmr.shape
-        assert isinstance(z, zarr.core.Array)
+        assert isinstance(z, zarr.Array)
 
 
 def test_get_array(single_page_tiff):


### PR DESCRIPTION
Fix #292 by wrapping the `ZarrTiffStore`'s storage mapping with `fsspec` so it can be used with zarr-python 3.

Also fixed deprecated TIFF and Zarr readers.