### PR TITLE
Catch json decoding error from incomplete NDTIFF

### DIFF
--- a/iohub/ndtiff.py
+++ b/iohub/ndtiff.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import warnings
+from json import JSONDecodeError
 from pathlib import Path
 from typing import Any, Iterable, Literal
 
@@ -336,7 +337,14 @@ class NDTiffDataset(MicroManagerFOVMapping):
                 p = int(p)
         p, t, c, z = self._check_coordinates(p, t, c, z)
         if self.dataset.has_image(position=p, time=t, channel=c, z=z):
-            metadata = self.dataset.read_metadata(
-                position=p, time=t, channel=c, z=z
-            )
+            try:
+                metadata = self.dataset.read_metadata(
+                    position=p, time=t, channel=c, z=z
+                )
+            except JSONDecodeError:
+                # acquisition crashed before metadata was written
+                _logger.warning(
+                    f"Unable to decode metadata for position {p}, "
+                    f"time {t}, channel {c}, z {z}"
+                )
         return metadata


### PR DESCRIPTION
Allows conversion of:

```
/hpc/instruments/jacobo.isim/Notch/20250501_cldnb-lyn-mScar_myo6b-bactin-gfp_she-h2b-gfp_Notch_LY40nM_timelapse/50_hpf_1
```