### PR TITLE
Update flake8-typing-imports version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: flake8
         args: [--ignore, "E203,W503", --min-python-version, '3.11']
-        additional_dependencies: [flake8-typing-imports==1.12.0]
+        additional_dependencies: [flake8-typing-imports==1.16.0]
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:


### PR DESCRIPTION
flake8-typing-imports==1.12.0 is not compatible with flake8 6.0.0