### PR TITLE
Contain logger configuration

### DIFF
--- a/iohub/__init__.py
+++ b/iohub/__init__.py
@@ -14,9 +14,18 @@ from iohub.reader import read_images
 __all__ = ["open_ome_zarr", "read_images"]
 
 
-_level = os.environ.get("IOHUB_LOG_LEVEL", logging.INFO)
-if str(_level).isdigit():
-    _level = int(_level)
+def _configure_logging():
+    """Configure logging for iohub."""
+    level = os.environ.get("IOHUB_LOG_LEVEL", logging.INFO)
+    if str(level).isdigit():
+        level = int(level)
+    iohub_logger = logging.getLogger(__name__)
+    iohub_logger.setLevel(level)
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(
+        logging.Formatter(fmt="%(levelname)s:%(name)s:%(message)s")
+    )
+    iohub_logger.addHandler(stream_handler)
 
-logging.basicConfig()
-logging.getLogger(__name__).setLevel(_level)
+
+_configure_logging()


### PR DESCRIPTION
Fix #317.

Explicitly set the handler for the iohub logger, instead of configuring the root logger.