### PR TITLE
Draft convert RGB images

### DIFF
--- a/iohub/convert.py
+++ b/iohub/convert.py
@@ -394,7 +394,8 @@ class TIFFConverter:
             ):
                 zarr_img = self.writer[zarr_pos_name]["0"]
                 to_zarr(fov.xdata.data.rechunk(self.chunks), zarr_img)
-                self._convert_image_plane_metadata(fov, zarr_img.path)
+                # Skip image plane metadata conversion, throws error
+                # self._convet_image_plane_metadata(fov, zarr_img.path)
         self.writer.zgroup.attrs.update(self.metadata)
         self.writer.close()
         self.reader.close()

--- a/iohub/mmstack.py
+++ b/iohub/mmstack.py
@@ -140,6 +140,13 @@ class MMStack(MicroManagerFOVMapping):
             (axis, size)
             for axis, size in zip(series.get_axes(), series.get_shape())
         )
+        _rgb = False
+        if "S" in raw_dims and "C" not in raw_dims:
+            # Map samples "S" from RGB images to channels "C"
+            # in datasets that don't already have a channel dimension
+            _rgb = True
+            _channels = raw_dims.pop("S")
+            raw_dims["C"] = _channels
         axes = ("R", "T", "C", "Z", "Y", "X")
         dims = dict((ax, raw_dims.get(ax, 1)) for ax in axes)
         _logger.debug(f"Got dataset dimensions from tifffile: {dims}.")
@@ -163,6 +170,9 @@ class MMStack(MicroManagerFOVMapping):
         xarr = img.expand_dims(
             [ax for ax in axes if ax not in img.dims]
         ).transpose(*axes)
+        # Rename RGB channels
+        if _rgb and self.channels == 3:
+            self.channel_names = ["Red", "Green", "Blue"]
         if self.channels > len(self.channel_names):
             for c in range(self.channels):
                 if c >= len(self.channel_names):


### PR DESCRIPTION
This is a draft / hack PR where I map Samples in RGB imaged to Channels. I think it may be possible to acquire two channels, where one channel is a standard grayscale fluorescence and the other channels is an RGB image, in which case this workaround would break. I've also commented out the image plane metadata conversion which currently doesn't work. Testing with data in `/hpc/instruments/cm.hummingbird/Amanda/2025_11_06_HandE_stitchng_test/HandE_stitch_test_3/`, converting in `/hpc/projects/comp.micro/exploratory/2025_11_06_HandE_stitchng_test/`