### PR TITLE
Opening HCS Plates from a Remote Store

### DIFF
--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -97,13 +97,13 @@ def test_cli_info_ome_zarr(verbose):
         cmd.append(verbose)
     result = runner.invoke(cli, cmd)
     assert result.exit_code == 0
-    assert re.search(r"Wells:\s+1", result.output)
+    assert re.search(r"Wells\s+1", result.output)
     assert ("Chunk size" in result.output) == bool(verbose)
-    assert ("No. bytes decompressed" in result.output) == bool(verbose)
+    assert ("Bytes (decompressed)" in result.output) == bool(verbose)
     # Test on single position
     result_pos = runner.invoke(cli, ["info", str(hcs_ref / "B" / "03" / "0")])
     assert "Channel names" in result_pos.output
-    assert "scale (um)" in result_pos.output
+    assert "scale (µm)" in result_pos.output
     assert "Chunk size" in result_pos.output
     assert "84.4 MiB" in result_pos.output
 

--- a/tests/ngff/test_remote.py
+++ b/tests/ngff/test_remote.py
@@ -1,0 +1,122 @@
+"""Tests for remote URL access (HTTP/HTTPS, S3, etc.)."""
+
+import numpy as np
+import pytest
+
+from iohub.ngff import open_ome_zarr
+from iohub.ngff.nodes import _is_remote_url, _open_store
+
+# Test datasets
+WAVEORDER_URL = (
+    "https://public.czbiohub.org/comp.micro/neurips_demos/waveorder/20x.zarr/"
+)
+VISCY_URL = (
+    "https://public.czbiohub.org/comp.micro/viscy/DynaCLR_data/DENV/test/"
+    "20240204_A549_DENV_ZIKV_timelapse/cropped_registered_test.zarr/"
+)
+
+
+class TestRemoteURLDetection:
+    """Test URL scheme detection."""
+
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            ("https://example.com/data.zarr", True),
+            ("http://example.com/data.zarr", True),
+            ("s3://bucket/data.zarr", True),
+            ("gs://bucket/data.zarr", True),
+            ("az://container/data.zarr", True),
+            ("/local/path/data.zarr", False),
+            ("relative/path/data.zarr", False),
+            ("C:\\Windows\\path\\data.zarr", False),
+        ],
+    )
+    def test_is_remote_url(self, url, expected):
+        assert _is_remote_url(url) == expected
+
+
+class TestRemoteWriteRestriction:
+    """Test that write modes are blocked for remote URLs."""
+
+    @pytest.mark.parametrize("mode", ["w", "w-", "a", "r+"])
+    def test_remote_write_not_supported(self, mode):
+        with pytest.raises(NotImplementedError, match="not supported for remote"):
+            _open_store("https://example.com/data.zarr", mode=mode, version="0.5")
+
+
+@pytest.mark.network
+class TestHTTPAccess:
+    """Tests requiring network access. Run with: pytest -m network"""
+
+    @pytest.fixture(scope="class")
+    def waveorder_fov(self):
+        """v0.5 single FOV (A/1/005028)."""
+        return open_ome_zarr(WAVEORDER_URL, mode="r")
+
+    @pytest.fixture(scope="class")
+    def viscy_plate(self):
+        """v0.4 plate with wells A/3 and B/4, position 9."""
+        return open_ome_zarr(VISCY_URL, mode="r")
+
+    # v0.5 tests
+    def test_v05_plate_metadata(self, waveorder_fov):
+        """Test v0.5 plate structure and metadata."""
+        ome = waveorder_fov.zattrs["ome"]
+        assert ome["version"] == "0.5"
+        assert len(ome["plate"]["wells"]) == 1
+        assert ome["plate"]["rows"][0]["name"] == "A"
+        assert ome["plate"]["columns"][0]["name"] == "1"
+
+    def test_v05_hierarchy_navigation(self, waveorder_fov):
+        """Test navigating plate -> well -> position -> array."""
+        well = waveorder_fov["A/1"]
+        assert "well" in well.zattrs["ome"]
+
+        pos = waveorder_fov["A/1/005028"]
+        assert "multiscales" in pos.zattrs["ome"]
+
+        arr = pos["0"]
+        assert arr.shape == (1, 1, 7, 512, 512)
+        assert arr.dtype == np.uint16
+
+    def test_v05_read_data(self, waveorder_fov):
+        """Test reading pixel data."""
+        data = waveorder_fov["A/1/005028"].data[0, 0, 0, :5, :5]
+        assert data.shape == (5, 5)
+        assert data.sum() > 0
+
+    # v0.4 tests
+    def test_v04_plate_metadata(self, viscy_plate):
+        """Test v0.4 plate structure and metadata."""
+        plate_meta = viscy_plate.zattrs["plate"]
+        assert plate_meta["version"] == "0.4"
+        assert len(plate_meta["wells"]) == 2
+        assert len(plate_meta["rows"]) == 2
+        assert len(plate_meta["columns"]) == 2
+
+    def test_v04_hierarchy_navigation(self, viscy_plate):
+        """Test navigating plate -> well -> position -> array."""
+        well = viscy_plate["A/3"]
+        assert "well" in well.zattrs
+
+        pos = viscy_plate["A/3/9"]
+        assert "multiscales" in pos.zattrs
+
+        arr = pos["0"]
+        assert arr.shape == (48, 4, 74, 1022, 1020)
+        assert arr.dtype == np.float32
+
+    def test_v04_multiple_wells(self, viscy_plate):
+        """Test accessing multiple wells."""
+        well_paths = [w["path"] for w in viscy_plate.zattrs["plate"]["wells"]]
+        assert set(well_paths) == {"A/3", "B/4"}
+
+        assert "well" in viscy_plate["A/3"].zattrs
+        assert "well" in viscy_plate["B/4"].zattrs
+
+    def test_v04_read_data(self, viscy_plate):
+        """Test reading pixel data."""
+        data = viscy_plate["A/3/9"].data[0, 0, 0, :5, :5]
+        assert data.shape == (5, 5)
+        assert data.dtype == np.float32


### PR DESCRIPTION
Added *read-only* support for opening OME-Zarr datasets from remote URLs (HTTP/HTTPS, S3, GCS, Azure).

In addition I made a small adjustment for to use metadata-based navigation instead of directory iteration (HTTP directory listings return HTML artifacts, so we read paths from OME-NGFF metadata files instead)

Here's how you use it:

```python
from iohub.ngff import open_ome_zarr

# Open from public dataset
dataset = open_ome_zarr(
    "https://public.czbiohub.org/comp.micro/neurips_demos/waveorder/20x.zarr/",
    mode="r"
)
```

or with the cli:

```shell
iohub info https://public.czbiohub.org/comp.micro/neurips_demos/waveorder/20x.zarr/ -v
```

I touched up the CLI output a bit as well since it used directory based traversal instead of metadata based one.
- Tree hierarchy now uses rich.Tree instead of manual box-drawing characters
- Summary displayed in a styled Panel with a two-column Table
- Abbreviated Space units (`µm`, `nm`, etc.) now read from OME-Zarr metadata instead of hardcoded to `um`.


```shell
Before:
=== Summary ===
Format:                  omezarr v0.4
(Z, Y, X) scale (um):    (0.1625, 0.1625)
...

After:
╭─────────────── Summary ───────────────╮
│  Format              omezarr v0.4    │
│  (Z, Y, X) scale (µm)  (0.1625, ...) │
│  ...                                 │
╰───────────────────────────────────────╯
```

Todos

- [x] Make sure iohub info works for remote stores over HTTP/HTTPS
- [ ] Add tests for S3, GCS, Azure... (maybe?)

Maybe in the future we can try to wrangle how we would want to do writes. It's also a good idea to address #265 after since I've touched a lot of the info printing code here, so it seems like relative modification.

As an aside I'm using `fssspec`, but `obstore` provides [greater performance](https://earthmover.io/blog/i-o-maxing-tensors-in-the-cloud) some of the time, however it doesn't work for simple servers like `caddy`, but it's great for S3 and such.