### PR TITLE
Don't let OME t_scale be equal to zero

### DIFF
--- a/iohub/mmstack.py
+++ b/iohub/mmstack.py
@@ -247,19 +247,18 @@ class MMStack(MicroManagerFOVMapping):
             for ch in self._mm_meta["Summary"].get("ChNames", []):
                 self.channel_names.append(ch)
         z_step_size = float(self._mm_meta["Summary"].get("z-step_um", 1.0))
-        if z_step_size == 0:
-            if self.slices == 1:
-                z_step_size = 1.0
-            else:
+        if z_step_size == 0.0:
+            z_step_size = 1.0
+            if self.slices != 1:
                 _logger.warning(
-                    f"Z-step size is {z_step_size} um in the metadata, "
-                    "Using 1.0 um instead."
+                    "Z-step size is set to 0.0 um in the metadata, "
+                    "using 1.0 um instead."
                 )
         self._z_step_size = z_step_size
         self.height = self._mm_meta["Summary"]["Height"]
         self.width = self._mm_meta["Summary"]["Width"]
         t_scale = float(self._mm_meta["Summary"].get("Interval_ms", 1e3)) / 1e3
-        if t_scale == 0:
+        if t_scale == 0.0:
             t_scale = 1.0
             _logger.warning(
                 "Time scale is set to 0.0 in the metadata, "


### PR DESCRIPTION
t_scale equal to zero causes issues with the napari viewer. t_scale of zero is not physically possible, so we default to 1.0 instead.

Fixes #343 