### PR TITLE
Add pyramid sharding

### DIFF
--- a/iohub/ngff/nodes.py
+++ b/iohub/ngff/nodes.py
@@ -1067,11 +1067,13 @@ class Position(NGFFNode):
                 _scale_integers(array.chunks, factor), len(shape)
             )
 
-            # TODO: first check if array is sharded?
-            shards = array.shards[:-3] + _scale_integers(
-                array.shards[-3:], factor
-            )
-            shards_ratio = tuple(s // c for c, s in zip(chunks, shards))
+            if array.shards is not None:
+                shards = array.shards[:-3] + _scale_integers(
+                    array.shards[-3:], factor
+                )
+                shards_ratio = tuple(s // c for c, s in zip(chunks, shards))
+            else:
+                shards_ratio = None
 
             transforms = deepcopy(
                 self.metadata.multiscales[0]
@@ -2261,8 +2263,7 @@ def open_ome_zarr(
     version: Literal["0.4", "0.5"] = "0.4",
     disable_path_checking: bool = False,
     **kwargs,
-) -> Plate | Position | TiledPosition:
-    ...
+) -> Plate | Position | TiledPosition: ...
 
 
 @overload
@@ -2275,8 +2276,7 @@ def open_ome_zarr(
     version: Literal["0.4", "0.5"] = "0.4",
     disable_path_checking: bool = False,
     **kwargs,
-) -> Position:
-    ...
+) -> Position: ...
 
 
 @overload
@@ -2289,8 +2289,7 @@ def open_ome_zarr(
     version: Literal["0.4", "0.5"] = "0.4",
     disable_path_checking: bool = False,
     **kwargs,
-) -> TiledPosition:
-    ...
+) -> TiledPosition: ...
 
 
 @overload
@@ -2303,8 +2302,7 @@ def open_ome_zarr(
     version: Literal["0.4", "0.5"] = "0.4",
     disable_path_checking: bool = False,
     **kwargs,
-) -> Plate:
-    ...
+) -> Plate: ...
 
 
 def open_ome_zarr(


### PR DESCRIPTION
@srivarra I found that the current pyramid code creates zarr v3 pyramid with small chunks and no sharing which results in lots of kb-size files, see `/hpc/projects/intracellular_dashboard/organelle_dynamics/2024_11_21_A549_TOMM20_DENV/2-assemble/zarr-v3/2024_11_21_A549_TOMM20_DENV.zarr/` for example. Here I'm adding sharding options in `initialize_pyramid`, which seems to work. I haven't yet tested what happens if the original store doesn't have sharding, or if the sharding along time decreased the compute efficiency.