### PR TITLE
fix: fix the chunking along Z (can handle prime numbers now)

### DIFF
--- a/src/iohub/convert.py
+++ b/src/iohub/convert.py
@@ -4,7 +4,6 @@ from importlib.metadata import version as _get_package_version
 from pathlib import Path
 from typing import Literal
 
-import dask
 import numpy as np
 from tqdm import tqdm
 from tqdm.contrib.itertools import product
@@ -267,7 +266,7 @@ class TIFFConverter:
 
         # Clamp chunks so they don't exceed dimension sizes
         chunks = _clamp_chunks_to_shape(shape, chunks)
-        for i, (orig, adj, dim) in enumerate(zip(original_chunks, chunks, shape)):
+        for i, (orig, adj, dim) in enumerate(zip(original_chunks, chunks, shape, strict=False)):
             if adj < orig:
                 _logger.warning(f"Chunk size {orig} on axis {i} clamped to {adj} (dimension size {dim}).")
 
@@ -384,13 +383,9 @@ class TIFFConverter:
         _logger.debug("Setting up Zarr store.")
 
         self._init_zarr_arrays()
-        # Calculate chunk size in bytes for dask config
-        # This prevents data loss when rechunking to zarr chunks
-        # See: https://github.com/czbiohub-sf/iohub/issues/367
-        chunk_size_bytes = int(np.prod(self.chunks) * np.dtype(self.reader.dtype).itemsize)
 
         _logger.debug("Converting images.")
-        with logging_redirect_tqdm(), dask.config.set({"array.chunk-size": chunk_size_bytes}):
+        with logging_redirect_tqdm():
             for zarr_pos_name, (_, fov) in tqdm(
                 zip(self.zarr_position_names, self.reader, strict=True),
                 total=len(self.zarr_position_names),

--- a/src/iohub/core/implementations/zarr_python.py
+++ b/src/iohub/core/implementations/zarr_python.py
@@ -139,9 +139,10 @@ class ZarrPythonImplementation(ZarrImplementation[zarr.Group, zarr.Array]):
         return da.from_zarr(handle)
 
     def write_from_dask(self, handle: zarr.Array, dask_array: Any) -> None:
-        from dask.array import to_zarr
+        from iohub.core.downsample import iter_work_regions
 
-        to_zarr(dask_array, handle)
+        for region in iter_work_regions(handle.shape, handle.chunks):
+            handle[region] = dask_array[region].compute()
 
     # -- High-performance operations ---------------------------------------
 

--- a/src/iohub/ngff/utils.py
+++ b/src/iohub/ngff/utils.py
@@ -462,46 +462,4 @@ def _clamp_chunks_to_shape(shape: tuple[int, ...], chunks: tuple[int, ...]) -> t
     tuple[int, ...]
         Chunk sizes clamped to at most the dimension size.
     """
-    return tuple(min(c, d) for c, d in zip(chunks, shape))
-
-
-def _downsample_tensorstore(
-    source_ts: ts.TensorStore,
-    target_ts: ts.TensorStore,
-    downsample_factors: list[int],
-    method: str = "mean",
-) -> None:
-    """Downsample source into target using tensorstore.
-
-    Writes data in chunks with transactions for consistency.
-
-    Parameters
-    ----------
-    source_ts : ts.TensorStore
-        Source tensorstore array to downsample from
-    target_ts : ts.TensorStore
-        Target tensorstore array to write downsampled data to
-    downsample_factors : list[int]
-        Downsampling factors for each dimension
-    method : str, optional
-        Downsampling method ("mean", "median", "mode", "min", "max",
-        "stride"), by default "mean"
-    """
-    try:
-        import tensorstore as ts
-    except ImportError:
-        raise ImportError(
-            "Tensorstore is required for downsampling. \
-            Please install it with `pip install tensorstore`."
-        )
-
-    downsampled = ts.downsample(source_ts, downsample_factors=downsample_factors, method=method)
-
-    step = target_ts.chunk_layout.write_chunk.shape[0]
-
-    for start in range(0, downsampled.shape[0], step):
-        with ts.Transaction() as txn:
-            target_with_txn = target_ts.with_transaction(txn)
-            downsampled_with_txn = downsampled.with_transaction(txn)
-            stop = min(start + step, downsampled.shape[0])
-            target_with_txn[start:stop].write(downsampled_with_txn[start:stop]).result()
+    return tuple(min(c, d) for c, d in zip(chunks, shape, strict=False))

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -350,7 +350,7 @@ def test_rechunk_xy_to_xyz_preserves_data(shape, target_chunks, tmpdir):
 
 
 @pytest.mark.parametrize(
-    "shape,target_chunks",
+    ("shape", "target_chunks"),
     [
         # Non-divisible Z: 1187 is prime, chunk 512 doesn't divide evenly
         ((1, 1, 1187, 256, 256), (1, 1, 512, 256, 256)),
@@ -365,7 +365,6 @@ def test_rechunk_non_divisible_z_preserves_data(shape, target_chunks, tmpdir):
     """
     import dask
     import dask.array as da
-    from dask.array import to_zarr
 
     data = np.arange(np.prod(shape), dtype=np.uint16).reshape(shape)
 
@@ -379,7 +378,7 @@ def test_rechunk_non_divisible_z_preserves_data(shape, target_chunks, tmpdir):
 
         chunk_size_bytes = int(np.prod(target_chunks) * 2)
         with dask.config.set({"array.chunk-size": chunk_size_bytes}):
-            to_zarr(dask_data.rechunk(target_chunks), zarr_img)
+            zarr_img.write_from_dask(dask_data.rechunk(target_chunks))
 
     with open_ome_zarr(output, layout="hcs", mode="r") as reader:
         written = reader["0/0/0"]["0"][:]


### PR DESCRIPTION
Removes the `_adjust_chunks_for_divisibility` function that reduced chunk sizes to evenly divide dimensions, replacing it with `_clamp_chunks_to_shape` that only caps chunks at the dimension size.

You'd encounter this with prime-sized dimensions (e.g., Z=1187) as they had their chunk size reduced to 1, since dask natively handles remainder chunks and the divisibility constraint was made redundant by the `dask.config.set({"array.chunk-size": ...}) `fix in #368.