### PR TITLE
pef: Lazy metadata access

### DIFF
--- a/src/iohub/ngff/models.py
+++ b/src/iohub/ngff/models.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import re
 from typing import Annotated, Any, Literal, Optional
 
-import pandas as pd
 from pydantic import (
     AfterValidator,
     BaseModel,
@@ -49,11 +48,9 @@ def unique_validator(data: list[BaseModel], field: str | list[str]) -> list[Base
         raised if any value is not unique
     """
     fields = [field] if isinstance(field, str) else field
-    if not isinstance(data[0], dict):
-        params = [d.model_dump() for d in data]
-    df = pd.DataFrame(params)
     for key in fields:
-        if not df[key].is_unique:
+        values = [d[key] if isinstance(d, dict) else getattr(d, key) for d in data]
+        if len(values) != len(set(values)):
             raise ValueError(f"'{key}' must be unique!")
     return data
 


### PR DESCRIPTION
**Why:** `open_ome_zarr()` on HCS plates had a throughput regression caused by two things in the metadata parsing path:

1. `_first_pos_attr()` used `next(group.groups())` to find the first position's channel_names/axes, but zarr v3's `groups()` eagerly enumerates all children before yielding the first; scaling linearly with FOVs/well (0.2ms for 1 FOV, 259ms for 2500)
2. `unique_validator()` built pandas DataFrames just to check field uniqueness

**Changes:**

- Made `axes` and `channel_names` lazy & cached via `functools.cached_property` on `NGFFNode` — they resolve on first access, not during `__init__`
- On `Plate`, overrode both with `cached_property` that uses direct path access (`self.zgroup[well_path][pos_name]`) instead of `groups()` traversal
- Replaced `unique_validator`'s `model_dump()` + pandas DataFrame with a simple `set` length check, removed the pandas import

**Before & After: on some test data**

| Plate | Wells | FOVs/well | Before | After | Speedup |
| :--- | ---: | ---: | ---: | ---: | ---: |
| tiny | 1 | 1 | 3.3 ms | 0.63 ms | 5.2x |
| few_wells | 6 | 1 | 3.6 ms | 0.71 ms | 5.1x |
| 96w_single | 96 | 1 | 7.2 ms | 0.78 ms | 9.2x |
| 96w_tiled | 96 | 25 | 12.0 ms | 0.90 ms | 13.3x |
| 25w_100fov | 25 | 100 | 25.2 ms | 0.68 ms | 37.1x |
| 384w_single | 384 | 1 | 11.3 ms | 1.13 ms | 10.0x |
| dense_tile | 1 | 2,500 | 535.8 ms | 0.67 ms | 799x |
