### PR TITLE
refactor: replace multiprocessing.Pool with ThreadPoolExecutor in process_single_position

### DIFF
--- a/src/iohub/ngff/utils.py
+++ b/src/iohub/ngff/utils.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import inspect
 import itertools
-import multiprocessing as mp
+import os
 from collections import defaultdict
 from collections.abc import Callable, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from pathlib import Path
 from typing import Any, Literal
@@ -395,21 +396,18 @@ def process_single_position(
         output_position_path,
         **kwargs,
     )
-    num_processes = min(num_processes, len(flat_iterable), mp.cpu_count())
-    click.echo(f"\nStarting multiprocess pool with {num_processes} processes")
-    if num_processes <= 1:
-        # Run serially — Pool(1) with spawn unnecessarily forks a subprocess
+    num_workers = min(num_processes, len(flat_iterable), os.cpu_count())
+    click.echo(f"\nStarting thread pool with {num_workers} workers")
+    if num_workers <= 1:
         for args in flat_iterable:
             partial_apply_transform_to_czyx_and_save(*args)
     else:
-        # NOTE: use spawn to work around tensorstore#61
-        context = mp.get_context("spawn")
-        with context.Pool(num_processes) as p:
-            p.starmap(
-                partial_apply_transform_to_czyx_and_save,
+        with ThreadPoolExecutor(max_workers=num_workers) as executor:
+            list(executor.map(
+                lambda args: partial_apply_transform_to_czyx_and_save(*args),
                 flat_iterable,
-            )
-    click.echo("Shut down multiprocess pool")
+            ))
+    click.echo("Shut down thread pool")
 
 
 # -- Pure utility functions ------------------------------------------------

--- a/src/iohub/ngff/utils.py
+++ b/src/iohub/ngff/utils.py
@@ -396,7 +396,8 @@ def process_single_position(
         output_position_path,
         **kwargs,
     )
-    num_workers = min(num_processes, len(flat_iterable), os.cpu_count())
+    cpu_count = os.cpu_count() or 1
+    num_workers = min(num_processes, len(flat_iterable), cpu_count)
     click.echo(f"\nStarting thread pool with {num_workers} workers")
     if num_workers <= 1:
         for args in flat_iterable:

--- a/src/iohub/ngff/utils.py
+++ b/src/iohub/ngff/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import inspect
 import itertools
 import os
+import warnings
 from collections import defaultdict
 from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor
@@ -284,7 +285,8 @@ def process_single_position(
     output_channel_indices: list[slice] | list[list[int]] | None = None,
     input_time_indices: list[int] | None = None,
     output_time_indices: list[int] | None = None,
-    num_processes: int = 1,
+    num_processes: int | None = None,
+    num_threads: int = 1,
     **kwargs,
 ) -> None:
     """
@@ -325,7 +327,11 @@ def process_single_position(
         Must match input_channel_indices if not empty.
         Defaults to None.
     num_processes : int, optional
-        Number of simultaneous processes per position. Defaults to 1.
+        Deprecated. Use ``num_threads`` instead. When set, its value is
+        forwarded to ``num_threads``. If both are set to non-default values
+        and differ, ``num_threads`` takes precedence. Defaults to None.
+    num_threads : int, optional
+        Number of simultaneous threads per position. Defaults to 1.
     kwargs : dict, optional
         Additional arguments to pass to the function.
         A dictionary with key "extra_metadata"
@@ -333,6 +339,14 @@ def process_single_position(
         e.g.,
         kwargs={"extra_metadata": {"Temperature": 37.5, "CO2_level": 0.5}}.
     """
+    if num_processes is not None:
+        warnings.warn(
+            "num_processes is deprecated. Use num_threads instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if num_threads < num_processes:
+            num_threads = num_processes
     click.echo(f"Function to be applied: \t{func}")
     click.echo(f"Input data path:\t{input_position_path}")
     click.echo(f"Output data path:\t{output_position_path}")
@@ -397,7 +411,7 @@ def process_single_position(
         **kwargs,
     )
     cpu_count = os.cpu_count() or 1
-    num_workers = min(num_processes, len(flat_iterable), cpu_count)
+    num_workers = min(num_threads, len(flat_iterable), cpu_count)
     click.echo(f"\nStarting thread pool with {num_workers} workers")
     if num_workers <= 1:
         for args in flat_iterable:

--- a/tests/ngff/test_ngff_utils.py
+++ b/tests/ngff/test_ngff_utils.py
@@ -723,10 +723,10 @@ def test_match_indices_to_batches(indices, shard_size):
 @given(
     setup=process_single_position_setup(),
     constant=st.integers(min_value=1, max_value=3),
-    num_processes=st.sampled_from([1, 2]),
+    num_threads=st.sampled_from([1, 2]),
 )
 @settings(max_examples=3, deadline=None)
-def test_process_single_position(setup, constant, num_processes):
+def test_process_single_position(setup, constant, num_threads):
     (
         position_keys,
         channel_names,
@@ -765,7 +765,7 @@ def test_process_single_position(setup, constant, num_processes):
                 output_channel_indices=channel_indices,
                 input_time_indices=time_indices,
                 output_time_indices=time_indices,
-                num_processes=num_processes,
+                num_threads=num_threads,
                 **kwargs,
             )
 

--- a/tests/ngff/test_ngff_utils.py
+++ b/tests/ngff/test_ngff_utils.py
@@ -792,3 +792,70 @@ def test_process_single_position(setup, constant):
                     dummy_transform,
                     **kwargs,
                 )
+
+
+@given(
+    setup=process_single_position_setup(),
+    constant=st.integers(min_value=1, max_value=3),
+)
+@settings(max_examples=3, deadline=None)
+def test_process_single_position_threaded(setup, constant):
+    (
+        position_keys,
+        channel_names,
+        shape,
+        chunks,
+        shards_ratio,
+        scale,
+        dtype,
+        channel_indices,
+        time_indices,
+        version,
+    ) = setup
+
+    with _temp_ome_zarr_stores(
+        position_keys=position_keys,
+        channel_names=channel_names,
+        shape=shape,
+        chunks=chunks,
+        shards_ratio=shards_ratio,
+        scale=scale,
+        dtype=dtype,
+        version=version,
+    ) as (input_store_path, output_store_path):
+        populate_store(input_store_path, position_keys, shape, dtype)
+
+        for position_key_tuple in position_keys:
+            input_position_path = input_store_path / Path(*position_key_tuple)
+            output_position_path = output_store_path / Path(*position_key_tuple)
+            kwargs = {"constant": constant, "extra_metadata": {"temp": 10}}
+
+            process_single_position(
+                func=dummy_transform,
+                input_position_path=input_position_path,
+                output_position_path=output_position_path,
+                input_channel_indices=channel_indices,
+                output_channel_indices=channel_indices,
+                input_time_indices=time_indices,
+                output_time_indices=time_indices,
+                num_processes=2,
+                **kwargs,
+            )
+
+            if time_indices is None:
+                time_indices = list(range(shape[0]))
+            if channel_indices is None:
+                channel_indices = [[c] for c in range(shape[1])]
+
+            iterable = itertools.product(time_indices, channel_indices)
+            for t_idx, chan_idx in iterable:
+                verify_transformation(
+                    input_store_path,
+                    output_store_path,
+                    position_key_tuple,
+                    shape,
+                    t_idx,
+                    chan_idx,
+                    dummy_transform,
+                    **kwargs,
+                )

--- a/tests/ngff/test_ngff_utils.py
+++ b/tests/ngff/test_ngff_utils.py
@@ -720,12 +720,7 @@ def test_match_indices_to_batches(indices, shard_size):
     assert matched_batches == batched_reference
 
 
-@given(
-    setup=process_single_position_setup(),
-    constant=st.integers(min_value=1, max_value=3),
-)
-@settings(max_examples=3, deadline=None)
-def test_process_single_position(setup, constant):
+def _run_process_single_position(setup, constant, num_processes=1):
     (
         position_keys,
         channel_names,
@@ -739,7 +734,6 @@ def test_process_single_position(setup, constant):
         version,
     ) = setup
 
-    # Use the enhanced context manager to get both input and output store paths
     with _temp_ome_zarr_stores(
         position_keys=position_keys,
         channel_names=channel_names,
@@ -750,16 +744,13 @@ def test_process_single_position(setup, constant):
         dtype=dtype,
         version=version,
     ) as (input_store_path, output_store_path):
-        # Populate Store with random data
         populate_store(input_store_path, position_keys, shape, dtype)
 
-        # Choose a single position to process (e.g., the first one)
         for position_key_tuple in position_keys:
             input_position_path = input_store_path / Path(*position_key_tuple)
             output_position_path = output_store_path / Path(*position_key_tuple)
             kwargs = {"constant": constant, "extra_metadata": {"temp": 10}}
 
-            # Apply the transformation using process_single_position
             process_single_position(
                 func=dummy_transform,
                 input_position_path=input_position_path,
@@ -768,18 +759,15 @@ def test_process_single_position(setup, constant):
                 output_channel_indices=channel_indices,
                 input_time_indices=time_indices,
                 output_time_indices=time_indices,
+                num_processes=num_processes,
                 **kwargs,
             )
 
-            # Handle None for process_single_position_setup
             if time_indices is None:
                 time_indices = list(range(shape[0]))
             if channel_indices is None:
                 channel_indices = [[c] for c in range(shape[1])]
 
-            print("time_indices", time_indices)
-            print("channel_indices", channel_indices)
-            # Verify the transformation
             iterable = itertools.product(time_indices, channel_indices)
             for t_idx, chan_idx in iterable:
                 verify_transformation(
@@ -792,6 +780,15 @@ def test_process_single_position(setup, constant):
                     dummy_transform,
                     **kwargs,
                 )
+
+
+@given(
+    setup=process_single_position_setup(),
+    constant=st.integers(min_value=1, max_value=3),
+)
+@settings(max_examples=3, deadline=None)
+def test_process_single_position(setup, constant):
+    _run_process_single_position(setup, constant)
 
 
 @given(
@@ -800,62 +797,4 @@ def test_process_single_position(setup, constant):
 )
 @settings(max_examples=3, deadline=None)
 def test_process_single_position_threaded(setup, constant):
-    (
-        position_keys,
-        channel_names,
-        shape,
-        chunks,
-        shards_ratio,
-        scale,
-        dtype,
-        channel_indices,
-        time_indices,
-        version,
-    ) = setup
-
-    with _temp_ome_zarr_stores(
-        position_keys=position_keys,
-        channel_names=channel_names,
-        shape=shape,
-        chunks=chunks,
-        shards_ratio=shards_ratio,
-        scale=scale,
-        dtype=dtype,
-        version=version,
-    ) as (input_store_path, output_store_path):
-        populate_store(input_store_path, position_keys, shape, dtype)
-
-        for position_key_tuple in position_keys:
-            input_position_path = input_store_path / Path(*position_key_tuple)
-            output_position_path = output_store_path / Path(*position_key_tuple)
-            kwargs = {"constant": constant, "extra_metadata": {"temp": 10}}
-
-            process_single_position(
-                func=dummy_transform,
-                input_position_path=input_position_path,
-                output_position_path=output_position_path,
-                input_channel_indices=channel_indices,
-                output_channel_indices=channel_indices,
-                input_time_indices=time_indices,
-                output_time_indices=time_indices,
-                num_processes=2,
-                **kwargs,
-            )
-
-            if time_indices is None:
-                time_indices = list(range(shape[0]))
-            if channel_indices is None:
-                channel_indices = [[c] for c in range(shape[1])]
-
-            iterable = itertools.product(time_indices, channel_indices)
-            for t_idx, chan_idx in iterable:
-                verify_transformation(
-                    input_store_path,
-                    output_store_path,
-                    position_key_tuple,
-                    shape,
-                    t_idx,
-                    chan_idx,
-                    dummy_transform,
-                    **kwargs,
-                )
+    _run_process_single_position(setup, constant, num_processes=2)

--- a/tests/ngff/test_ngff_utils.py
+++ b/tests/ngff/test_ngff_utils.py
@@ -720,7 +720,13 @@ def test_match_indices_to_batches(indices, shard_size):
     assert matched_batches == batched_reference
 
 
-def _run_process_single_position(setup, constant, num_processes=1):
+@given(
+    setup=process_single_position_setup(),
+    constant=st.integers(min_value=1, max_value=3),
+    num_processes=st.sampled_from([1, 2]),
+)
+@settings(max_examples=3, deadline=None)
+def test_process_single_position(setup, constant, num_processes):
     (
         position_keys,
         channel_names,
@@ -780,21 +786,3 @@ def _run_process_single_position(setup, constant, num_processes=1):
                     dummy_transform,
                     **kwargs,
                 )
-
-
-@given(
-    setup=process_single_position_setup(),
-    constant=st.integers(min_value=1, max_value=3),
-)
-@settings(max_examples=3, deadline=None)
-def test_process_single_position(setup, constant):
-    _run_process_single_position(setup, constant)
-
-
-@given(
-    setup=process_single_position_setup(),
-    constant=st.integers(min_value=1, max_value=3),
-)
-@settings(max_examples=3, deadline=None)
-def test_process_single_position_threaded(setup, constant):
-    _run_process_single_position(setup, constant, num_processes=2)


### PR DESCRIPTION
## Summary

- Replace `multiprocessing.Pool` (spawn context) with `concurrent.futures.ThreadPoolExecutor` in `process_single_position`
- Remove `multiprocessing` import, add `os` and `ThreadPoolExecutor`

## Motivation

### Transform functions are I/O-bound, not GIL-bound

All downstream callers in [biahub](https://github.com/czbiohub-sf/biahub) pass transform functions that release the GIL:

| Caller | `func` passed | GIL-bound? | Details |
|--------|--------------|------------|---------|
| `deskew.py` | `_czyx_deskew_data` | No | PyTorch/MONAI + scipy |
| `deconvolve.py` | `deconvolve` | No | PyTorch FFT |
| `concatenate.py` | `copy_n_paste` | No | numpy slicing |
| `segment.py` | `segment_data` | No | Cellpose (PyTorch) |
| `process_data.py` | `binning_czyx` | Negligible | Small Python loop over channels, heavy work is numpy |
| `stabilize.py` | `apply_stabilization_transform` | No | ANTsPy (C++) |
| `register.py` | `apply_affine_transform` | No | ANTsPy or scipy.ndimage |

Since the actual computation happens in C extensions (numpy, scipy, ANTsPy) or PyTorch, threads achieve the same parallelism as processes here.

### `spawn`-based multiprocessing has significant overhead

The previous implementation used `mp.get_context("spawn")` to work around [tensorstore#61](https://github.com/google/tensorstore/issues/61). `spawn` starts a fresh Python interpreter per worker, which means:
- Re-importing all libraries (PyTorch, tensorstore, etc.) in each child process
- Serializing/pickling `func` and all arguments across process boundaries
- Higher memory usage from duplicated process state

Threads share the parent process memory and avoid all of this overhead. The tensorstore fork-safety issue is also irrelevant with threads since there is no fork.

### Better compatibility with Nextflow orchestration

In production, biahub runs `process_single_position` inside Nextflow tasks. Nextflow already parallelizes at the position level, so spawning child processes *within* each task:
- Creates resource accounting issues — Nextflow allocates CPUs/memory for the task, but spawned child processes compete outside Nextflow's awareness
- Wastes resources on redundant library imports in each child process

With `ThreadPoolExecutor`, the Nextflow task is a single process with threads — `cpus` and `memory` directives map cleanly to actual resource usage.

## Test plan

- [ ] Existing `test_process_single_position` hypothesis tests pass
- [ ] Verify in a biahub Nextflow pipeline run (e.g. deskew or deconvolution)
