### PR TITLE
Roll back converter default to ome-ngff 0.4

### DIFF
--- a/src/iohub/cli/cli.py
+++ b/src/iohub/cli/cli.py
@@ -81,9 +81,9 @@ def info(files, verbose):
     "--ome-zarr-version",
     "-v",
     required=False,
-    default="0.5",
-    type=click.Choice(["0.5"]),
-    help="OME-NGFF version for the output Zarr store. '0.5' uses Zarr v3 format.",
+    default="0.4",
+    type=click.Choice(["0.4", "0.5"]),
+    help="OME-NGFF version for the output Zarr store. '0.4' uses Zarr v2 format; '0.5' uses Zarr v3 format.",
 )
 def convert(input, output, grid_layout, chunks, ome_zarr_version):
     """Converts Micro-Manager TIFF datasets to OME-Zarr"""

--- a/src/iohub/convert.py
+++ b/src/iohub/convert.py
@@ -92,8 +92,8 @@ class TIFFConverter:
         and is ignored for other formats, by default None
         (attempt to apply to OME-TIFF datasets, disable this with ``False``)
     version : Literal["0.4", "0.5"], optional
-        OME-NGFF version for the output Zarr store, by default "0.5".
-        Both versions use Zarr v3 format; "0.4" is deprecated for new stores.
+        OME-NGFF version for the output Zarr store, by default "0.4".
+        "0.4" uses Zarr v2 format; "0.5" uses Zarr v3 format.
     implementation : str, optional
         Zarr backend implementation to use for writing.
         None (default) uses zarr-python. Pass "tensorstore"
@@ -113,7 +113,7 @@ class TIFFConverter:
         grid_layout: int = False,
         chunks: tuple[int] | Literal["XY", "XYZ"] | None = None,
         hcs_plate: bool | None = None,
-        version: Literal["0.4", "0.5"] = "0.5",
+        version: Literal["0.4", "0.5"] = "0.4",
         implementation: str | None = None,
     ):
         self.implementation = implementation

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -390,10 +390,10 @@ class TestVersionParameter:
     """Tests for the OME-NGFF version parameter on TIFFConverter."""
 
     def test_default_version(self, example_ome_tiff, tmpdir):
-        """Default version should be '0.5'."""
+        """Default version should be '0.4'."""
         output = tmpdir / "converted.zarr"
         converter = TIFFConverter(example_ome_tiff, output)
-        assert converter.version == "0.5"
+        assert converter.version == "0.4"
 
     @pytest.mark.parametrize("ver", ["0.5"])
     def test_explicit_version(self, example_ome_tiff, tmpdir, ver):


### PR DESCRIPTION
We need to roll back the convert to v0.4 as own downstream processing pipelines are not yet ready to handle 0.5 data. 

@srivarra can you please merge this commit and create a iohub 0.3.3 pipy release?

We'll revert this PR once our processing pipelines are ready.