### PR TITLE
Implement version-specific default chunk and shard sizes in iohub utils

### DIFF
--- a/src/iohub/core/compat.py
+++ b/src/iohub/core/compat.py
@@ -7,6 +7,12 @@ from iohub.core.types import NGFFVersion, ZarrFormat
 NGFF_TO_ZARR_FORMAT: dict[str, int] = {"0.4": 2, "0.5": 3}
 ZARR_FORMAT_TO_NGFF: dict[int, str] = {2: "0.4", 3: "0.5"}
 
+#: Maximum chunk size in bytes for the v0.4 default-chunk calculation.
+#: v0.4 (Zarr v2) does not support sharding, so the default chunk shape
+#: ``(1, 1, Z, Y, X)`` has Z halved until the single-chunk byte size fits
+#: under this cap.
+V04_MAX_CHUNK_SIZE_BYTES: float = 500e6
+
 
 def zarr_format_for_version(version: NGFFVersion) -> ZarrFormat:
     """Map NGFF version string to zarr format integer."""

--- a/src/iohub/ngff/utils.py
+++ b/src/iohub/ngff/utils.py
@@ -19,6 +19,13 @@ from iohub.ngff import open_ome_zarr
 from iohub.ngff.nodes import TransformationMeta
 
 
+#: Default ZYX chunk size for OME-Zarr v0.5 stores: ~2 MB at uint16 / ~4 MB at float32.
+_V05_DEFAULT_ZYX_CHUNKS: tuple[int, int, int] = (16, 256, 256)
+
+#: Maximum chunk size in bytes used for the v0.4 default-chunk calculation.
+_V04_MAX_CHUNK_SIZE_BYTES: float = 500e6
+
+
 def create_empty_plate(
     store_path: Path,
     position_keys: list[tuple[str, str, str]],
@@ -29,7 +36,6 @@ def create_empty_plate(
     version: Literal["0.4", "0.5"] = "0.5",
     scale: tuple[float, ...] = (1, 1, 1, 1, 1),
     dtype: DTypeLike = np.float32,
-    max_chunk_size_bytes: float = 500e6,
 ) -> None:
     """
     Create a new HCS Plate in OME-Zarr format if the plate does not exist.
@@ -50,22 +56,24 @@ def create_empty_plate(
     shape : tuple[int, ...]
         TCZYX shape of the plate.
     chunks : tuple[int, ...], optional
-        TCZYX chunk size of the plate. If None, the chunk size is calculated
-        based on the shape to be less than max_chunk_size_bytes.
+        TCZYX chunk size of the plate. If None, a version-specific default
+        is used:
+        - "0.4": ``(1, 1, Z, Y, X)`` capped in Z to 500 MB.
+        - "0.5": ``(1, 1, 16, 256, 256)`` clamped to ``shape``.
         Defaults to None.
     shards_ratio : tuple[int, ...], optional
-        TCZYX shards ratio of the plate.
-        If None, no sharding is applied.
+        TCZYX shards ratio of the plate (shard size = chunks * shards_ratio).
+        If None, a version-specific default is used:
+        - "0.4": no sharding (Zarr v2 does not support it).
+        - "0.5": ratio that yields a shard size of ``(1, 1, Z, Y, X)``.
         Defaults to None.
     version : Literal["0.4", "0.5"], optional
         OME-Zarr version to use for the plate.
-        Defaults to "0.4".
+        Defaults to "0.5".
     scale : tuple[float, ...], optional
         TCZYX scale of the plate. Defaults to (1, 1, 1, 1, 1).
     dtype : DTypeLike, optional
         Data type of the plate. Defaults to np.float32.
-    max_chunk_size_bytes : float, optional
-        Maximum chunk size in bytes. Defaults to 500e6 (500MB).
 
     Examples
     --------
@@ -101,20 +109,16 @@ def create_empty_plate(
 
     Notes
     -----
-    - If `chunks` is not provided, the function calculates an appropriate
-    chunk size to keep the chunks under the specified `max_chunk_size_bytes`.
+    - If `chunks` is not provided, a version-specific default is used (see
+    parameter description).
     - The function ensures that positions and channels are appended to an
     existing plate if they are not already present.
     """
-    # Limiting the chunking to 500MB
     if chunks is None:
-        chunk_zyx_shape = _limit_zyx_chunk_size(
-            shape,
-            np.dtype(dtype).itemsize,
-            max_chunk_size_bytes,
-        )
+        chunks = _default_chunks(shape, dtype, version)
 
-        chunks = 2 * (1,) + chunk_zyx_shape
+    if shards_ratio is None and version == "0.5":
+        shards_ratio = _default_shards_ratio(shape, chunks)
 
     # Create plate
     output_plate = open_ome_zarr(
@@ -478,3 +482,31 @@ def _clamp_chunks_to_shape(shape: tuple[int, ...], chunks: tuple[int, ...]) -> t
         Chunk sizes clamped to at most the dimension size.
     """
     return tuple(min(c, d) for c, d in zip(chunks, shape, strict=False))
+
+
+def _default_chunks(
+    shape: tuple[int, ...],
+    dtype: DTypeLike,
+    version: Literal["0.4", "0.5"],
+) -> tuple[int, ...]:
+    """Version-specific default TCZYX chunk size for a plate array."""
+    if version == "0.4":
+        chunk_zyx_shape = _limit_zyx_chunk_size(
+            shape,
+            np.dtype(dtype).itemsize,
+            _V04_MAX_CHUNK_SIZE_BYTES,
+        )
+        return (1, 1, *chunk_zyx_shape)
+    # v0.5: DCA-aligned small chunks, clamped to the array shape.
+    return _clamp_chunks_to_shape(shape, (1, 1, *_V05_DEFAULT_ZYX_CHUNKS))
+
+
+def _default_shards_ratio(
+    shape: tuple[int, ...],
+    chunks: tuple[int, ...],
+) -> tuple[int, ...]:
+    """Shards ratio yielding a shard of (1, 1, Z, Y, X)."""
+    ratios = [1, 1]
+    for dim, chunk in zip(shape[-3:], chunks[-3:], strict=False):
+        ratios.append(-(-dim // chunk))
+    return tuple(ratios)

--- a/src/iohub/ngff/utils.py
+++ b/src/iohub/ngff/utils.py
@@ -15,15 +15,13 @@ import click
 import numpy as np
 from numpy.typing import DTypeLike, NDArray
 
+from iohub.core.compat import V04_MAX_CHUNK_SIZE_BYTES
 from iohub.ngff import open_ome_zarr
 from iohub.ngff.nodes import TransformationMeta
 
 
 #: Default ZYX chunk size for OME-Zarr v0.5 stores: ~2 MB at uint16 / ~4 MB at float32.
 _V05_DEFAULT_ZYX_CHUNKS: tuple[int, int, int] = (16, 256, 256)
-
-#: Maximum chunk size in bytes used for the v0.4 default-chunk calculation.
-_V04_MAX_CHUNK_SIZE_BYTES: float = 500e6
 
 
 def create_empty_plate(
@@ -494,7 +492,7 @@ def _default_chunks(
         chunk_zyx_shape = _limit_zyx_chunk_size(
             shape,
             np.dtype(dtype).itemsize,
-            _V04_MAX_CHUNK_SIZE_BYTES,
+            V04_MAX_CHUNK_SIZE_BYTES,
         )
         return (1, 1, *chunk_zyx_shape)
     # v0.5: DCA-aligned small chunks, clamped to the array shape.

--- a/tests/ngff/test_ngff_utils.py
+++ b/tests/ngff/test_ngff_utils.py
@@ -11,11 +11,11 @@ import pytest
 from hypothesis import assume, given, settings
 from numpy.typing import DTypeLike
 
+from iohub.core.compat import V04_MAX_CHUNK_SIZE_BYTES
 from iohub.ngff import open_ome_zarr
 from iohub.ngff.utils import (
     _indices_to_shard_aligned_batches,
     _match_indices_to_batches,
-    _V04_MAX_CHUNK_SIZE_BYTES,
     _V05_DEFAULT_ZYX_CHUNKS,
     apply_transform_to_tczyx_and_save,
     create_empty_plate,
@@ -915,7 +915,7 @@ def test_v04_default_chunks_cover_full_zyx(tmp_path):
 
 
 def test_v04_default_chunks_capped_by_byte_limit(tmp_path):
-    """v0.4 chunks halve Z until the chunk fits under _V04_MAX_CHUNK_SIZE_BYTES."""
+    """v0.4 chunks halve Z until the chunk fits under V04_MAX_CHUNK_SIZE_BYTES."""
     # Pick a shape whose single (Z, Y, X) volume in float32 exceeds the cap.
     # float32 is 4 bytes; cap is 500 MB → a (256, 1024, 1024) volume is
     # 1 GiB, so the default must halve Z at least once.
@@ -936,7 +936,7 @@ def test_v04_default_chunks_capped_by_byte_limit(tmp_path):
     assert (y_chunk, x_chunk) == (shape[3], shape[4])
     assert z_chunk < shape[2], "Z should have been halved to respect byte cap"
     bytes_per_chunk = z_chunk * y_chunk * x_chunk * np.dtype(dtype).itemsize
-    assert bytes_per_chunk <= _V04_MAX_CHUNK_SIZE_BYTES
+    assert bytes_per_chunk <= V04_MAX_CHUNK_SIZE_BYTES
 
 
 def test_v04_default_has_no_sharding(tmp_path):

--- a/tests/ngff/test_ngff_utils.py
+++ b/tests/ngff/test_ngff_utils.py
@@ -969,11 +969,9 @@ def test_v04_rejects_explicit_shards_ratio(tmp_path):
 
 # -- Write path on sharded v0.5 stores ---------------------------------------
 #
-# iohub ships with ``zarrs`` as a required dependency and the
-# ``ZarrsCodecPipeline`` is the active codec pipeline. That pipeline handles
-# oindex writes into sharded Zarr v3 arrays correctly, so the upstream
-# zarr-python#2834 bug (which affects ``BatchedCodecPipeline``) does not
-# surface through iohub's default code path. These tests pin that behavior.
+# Round-trip writes into v0.5 stores with non-trivial shard layouts,
+# exercising both the #401 default (shard per (T, C) slot) and a
+# channel-spanning shard that groups multiple channels into one shard.
 
 
 def test_process_single_position_on_sharded_v05_store(tmp_path):
@@ -1012,16 +1010,16 @@ def test_process_single_position_on_sharded_v05_store(tmp_path):
     np.testing.assert_array_almost_equal(out_data, dummy_transform(in_data, constant=2))
 
 
-def test_apply_transform_to_tczyx_on_multi_time_shard(tmp_path):
-    """Multi-time oindex write into a shard that spans multiple T slots.
+def test_apply_transform_to_tczyx_on_multi_channel_shard(tmp_path):
+    """Multi-channel oindex write into a shard that spans multiple C slots.
 
-    This is the exact pattern that breaks under zarr-python's default
-    ``BatchedCodecPipeline`` (upstream bug #2834). It works under iohub's
-    ``ZarrsCodecPipeline``-backed config, which is the guarantee we want
-    to lock in.
+    Grouping channels within a single shard is a common layout for
+    stores produced downstream (e.g. multi-channel stitched outputs);
+    ``apply_transform_to_tczyx_and_save`` should round-trip correctly
+    when the write addresses both channels of a single shard in one call.
     """
-    shape = (4, 1, 4, 16, 16)
-    shards_ratio = (2, 1, 1, 1, 1)  # shard_t = 2 -> one write spans both T slots
+    shape = (1, 4, 4, 16, 16)
+    shards_ratio = (1, 2, 1, 1, 1)  # shard_c = 2 -> one write spans two C slots
     position_key = ("A", "1", "0")
     input_store = tmp_path / "input.zarr"
     output_store = tmp_path / "output.zarr"
@@ -1029,7 +1027,7 @@ def test_apply_transform_to_tczyx_on_multi_time_shard(tmp_path):
         create_empty_plate(
             store_path=store,
             position_keys=[position_key],
-            channel_names=["c0"],
+            channel_names=[f"c{i}" for i in range(shape[1])],
             shape=shape,
             chunks=(1, 1, 4, 16, 16),
             shards_ratio=shards_ratio,
@@ -1041,14 +1039,14 @@ def test_apply_transform_to_tczyx_on_multi_time_shard(tmp_path):
         func=dummy_transform,
         input_position_path=input_store / Path(*position_key),
         output_position_path=output_store / Path(*position_key),
-        input_channel_indices=[0],
-        output_channel_indices=[0],
-        input_time_indices=[0, 1],
-        output_time_indices=[0, 1],
+        input_channel_indices=[0, 1],
+        output_channel_indices=[0, 1],
+        input_time_indices=[0],
+        output_time_indices=[0],
         constant=2,
     )
 
     with open_ome_zarr(input_store) as in_ds, open_ome_zarr(output_store) as out_ds:
-        in_slice = in_ds["/".join(position_key)].data[:2, :1]
-        out_slice = out_ds["/".join(position_key)].data[:2, :1]
+        in_slice = in_ds["/".join(position_key)].data[:1, :2]
+        out_slice = out_ds["/".join(position_key)].data[:1, :2]
     np.testing.assert_array_almost_equal(out_slice, dummy_transform(in_slice, constant=2))

--- a/tests/ngff/test_ngff_utils.py
+++ b/tests/ngff/test_ngff_utils.py
@@ -7,6 +7,7 @@ from typing import Literal
 
 import hypothesis.strategies as st
 import numpy as np
+import pytest
 from hypothesis import assume, given, settings
 from numpy.typing import DTypeLike
 
@@ -14,6 +15,8 @@ from iohub.ngff import open_ome_zarr
 from iohub.ngff.utils import (
     _indices_to_shard_aligned_batches,
     _match_indices_to_batches,
+    _V04_MAX_CHUNK_SIZE_BYTES,
+    _V05_DEFAULT_ZYX_CHUNKS,
     apply_transform_to_tczyx_and_save,
     create_empty_plate,
     process_single_position,
@@ -786,3 +789,255 @@ def test_process_single_position(setup, constant, num_threads):
                     dummy_transform,
                     **kwargs,
                 )
+
+
+# -- Explicit tests for version-specific chunk/shard defaults -----------------
+#
+# The hypothesis-based test_create_empty_plate exercises many parameter
+# combinations but does not assert the exact defaults the issue #401 spec
+# prescribes. These tests pin those defaults down so CI fails deterministically
+# if they regress, rather than relying on a favorable hypothesis draw.
+
+
+def _open_array(store_path: Path, position_key: tuple[str, str, str]):
+    return open_ome_zarr(store_path)["/".join(position_key)].data
+
+
+@pytest.mark.parametrize(
+    ("shape", "expected_chunks"),
+    [
+        # Large shape: chunks clamped to DCA spec (16, 256, 256).
+        ((2, 2, 64, 1024, 1024), (1, 1, 16, 256, 256)),
+        # Small Z: clamped to Z.
+        ((2, 2, 8, 1024, 1024), (1, 1, 8, 256, 256)),
+        # Small YX: clamped to YX.
+        ((2, 2, 64, 128, 200), (1, 1, 16, 128, 200)),
+        # Fully smaller than defaults.
+        ((1, 1, 4, 32, 32), (1, 1, 4, 32, 32)),
+    ],
+)
+def test_v05_default_chunks(tmp_path, shape, expected_chunks):
+    """v0.5 default chunks are DCA-aligned (16, 256, 256), clamped to shape."""
+    store = tmp_path / "test.zarr"
+    create_empty_plate(
+        store_path=store,
+        position_keys=[("A", "1", "0")],
+        channel_names=[f"c{i}" for i in range(shape[1])],
+        shape=shape,
+        version="0.5",
+    )
+    arr = _open_array(store, ("A", "1", "0"))
+    assert arr.chunks == expected_chunks
+
+
+def test_v05_default_shards_cover_zyx(tmp_path):
+    """v0.5 default shards have shape (1, 1, Z, Y, X) — one shard per (T, C)."""
+    shape = (3, 2, 64, 1024, 1024)
+    store = tmp_path / "test.zarr"
+    create_empty_plate(
+        store_path=store,
+        position_keys=[("A", "1", "0")],
+        channel_names=[f"c{i}" for i in range(shape[1])],
+        shape=shape,
+        version="0.5",
+    )
+    arr = _open_array(store, ("A", "1", "0"))
+    # Shard spans one full (Z, Y, X) volume per (T, C) slot.
+    assert arr.shards == (1, 1, shape[2], shape[3], shape[4])
+    # And chunks stay DCA-aligned.
+    assert arr.chunks == (1, 1, *_V05_DEFAULT_ZYX_CHUNKS)
+
+
+def test_v05_default_shards_with_non_divisible_zyx(tmp_path):
+    """Shards still cover the full (Z, Y, X) even when dims are not multiples of chunks."""
+    # Z=20, Y=300, X=300 — none divide evenly into (16, 256, 256).
+    shape = (1, 1, 20, 300, 300)
+    store = tmp_path / "test.zarr"
+    create_empty_plate(
+        store_path=store,
+        position_keys=[("A", "1", "0")],
+        channel_names=["c0"],
+        shape=shape,
+        version="0.5",
+    )
+    arr = _open_array(store, ("A", "1", "0"))
+    # Shard = chunk * ceil(dim/chunk) — must be >= dim along each axis.
+    assert arr.chunks == (1, 1, 16, 256, 256)
+    assert arr.shards[0] == 1
+    assert arr.shards[1] == 1
+    assert arr.shards[2] >= 20
+    assert arr.shards[3] >= 300
+    assert arr.shards[4] >= 300
+
+
+def test_v05_explicit_shards_ratio_is_honored(tmp_path):
+    """An explicit shards_ratio overrides the default."""
+    shape = (4, 2, 16, 256, 256)
+    store = tmp_path / "test.zarr"
+    create_empty_plate(
+        store_path=store,
+        position_keys=[("A", "1", "0")],
+        channel_names=[f"c{i}" for i in range(shape[1])],
+        shape=shape,
+        chunks=(1, 1, 16, 256, 256),
+        shards_ratio=(2, 2, 1, 1, 1),
+        version="0.5",
+    )
+    arr = _open_array(store, ("A", "1", "0"))
+    assert arr.chunks == (1, 1, 16, 256, 256)
+    assert arr.shards == (2, 2, 16, 256, 256)
+
+
+def test_v04_default_chunks_cover_full_zyx(tmp_path):
+    """v0.4 default chunks are (1, 1, Z, Y, X) when under the byte cap."""
+    shape = (2, 2, 4, 64, 64)
+    store = tmp_path / "test.zarr"
+    create_empty_plate(
+        store_path=store,
+        position_keys=[("A", "1", "0")],
+        channel_names=[f"c{i}" for i in range(shape[1])],
+        shape=shape,
+        version="0.4",
+    )
+    arr = _open_array(store, ("A", "1", "0"))
+    assert arr.chunks == (1, 1, shape[2], shape[3], shape[4])
+
+
+def test_v04_default_chunks_capped_by_byte_limit(tmp_path):
+    """v0.4 chunks halve Z until the chunk fits under _V04_MAX_CHUNK_SIZE_BYTES."""
+    # Pick a shape whose single (Z, Y, X) volume in float32 exceeds the cap.
+    # float32 is 4 bytes; cap is 500 MB → a (256, 1024, 1024) volume is
+    # 1 GiB, so the default must halve Z at least once.
+    shape = (1, 1, 256, 1024, 1024)
+    dtype = np.float32
+    store = tmp_path / "test.zarr"
+    create_empty_plate(
+        store_path=store,
+        position_keys=[("A", "1", "0")],
+        channel_names=["c0"],
+        shape=shape,
+        dtype=dtype,
+        version="0.4",
+    )
+    arr = _open_array(store, ("A", "1", "0"))
+    t_chunk, c_chunk, z_chunk, y_chunk, x_chunk = arr.chunks
+    assert (t_chunk, c_chunk) == (1, 1)
+    assert (y_chunk, x_chunk) == (shape[3], shape[4])
+    assert z_chunk < shape[2], "Z should have been halved to respect byte cap"
+    bytes_per_chunk = z_chunk * y_chunk * x_chunk * np.dtype(dtype).itemsize
+    assert bytes_per_chunk <= _V04_MAX_CHUNK_SIZE_BYTES
+
+
+def test_v04_default_has_no_sharding(tmp_path):
+    """v0.4 (Zarr v2) never has a sharding codec, regardless of the new defaults."""
+    store = tmp_path / "test.zarr"
+    create_empty_plate(
+        store_path=store,
+        position_keys=[("A", "1", "0")],
+        channel_names=["c0"],
+        shape=(2, 1, 8, 64, 64),
+        version="0.4",
+    )
+    arr = _open_array(store, ("A", "1", "0"))
+    assert arr.shards is None
+
+
+def test_v04_rejects_explicit_shards_ratio(tmp_path):
+    """Passing shards_ratio on a v0.4 store raises (Zarr v2 has no sharding)."""
+    store = tmp_path / "test.zarr"
+    with pytest.raises(ValueError, match="Sharding is not supported in Zarr v2"):
+        create_empty_plate(
+            store_path=store,
+            position_keys=[("A", "1", "0")],
+            channel_names=["c0"],
+            shape=(2, 1, 8, 64, 64),
+            shards_ratio=(1, 1, 1, 1, 1),
+            version="0.4",
+        )
+
+
+# -- Write path on sharded v0.5 stores ---------------------------------------
+#
+# iohub ships with ``zarrs`` as a required dependency and the
+# ``ZarrsCodecPipeline`` is the active codec pipeline. That pipeline handles
+# oindex writes into sharded Zarr v3 arrays correctly, so the upstream
+# zarr-python#2834 bug (which affects ``BatchedCodecPipeline``) does not
+# surface through iohub's default code path. These tests pin that behavior.
+
+
+def test_process_single_position_on_sharded_v05_store(tmp_path):
+    """process_single_position writes to a default-sharded v0.5 store correctly."""
+    shape = (2, 1, 4, 16, 16)
+    position_key = ("A", "1", "0")
+    input_store = tmp_path / "input.zarr"
+    output_store = tmp_path / "output.zarr"
+    for store in (input_store, output_store):
+        create_empty_plate(
+            store_path=store,
+            position_keys=[position_key],
+            channel_names=["c0"],
+            shape=shape,
+            version="0.5",
+        )
+    populate_store(input_store, [position_key], shape, np.float32)
+
+    process_single_position(
+        func=dummy_transform,
+        input_position_path=input_store / Path(*position_key),
+        output_position_path=output_store / Path(*position_key),
+        input_channel_indices=[[0]],
+        output_channel_indices=[[0]],
+        input_time_indices=[0, 1],
+        output_time_indices=[0, 1],
+        constant=2,
+    )
+
+    out_arr = _open_array(output_store, position_key)
+    assert out_arr.shards == (1, 1, shape[2], shape[3], shape[4])
+
+    with open_ome_zarr(input_store) as in_ds, open_ome_zarr(output_store) as out_ds:
+        in_data = in_ds["/".join(position_key)].data[:]
+        out_data = out_ds["/".join(position_key)].data[:]
+    np.testing.assert_array_almost_equal(out_data, dummy_transform(in_data, constant=2))
+
+
+def test_apply_transform_to_tczyx_on_multi_time_shard(tmp_path):
+    """Multi-time oindex write into a shard that spans multiple T slots.
+
+    This is the exact pattern that breaks under zarr-python's default
+    ``BatchedCodecPipeline`` (upstream bug #2834). It works under iohub's
+    ``ZarrsCodecPipeline``-backed config, which is the guarantee we want
+    to lock in.
+    """
+    shape = (4, 1, 4, 16, 16)
+    shards_ratio = (2, 1, 1, 1, 1)  # shard_t = 2 -> one write spans both T slots
+    position_key = ("A", "1", "0")
+    input_store = tmp_path / "input.zarr"
+    output_store = tmp_path / "output.zarr"
+    for store in (input_store, output_store):
+        create_empty_plate(
+            store_path=store,
+            position_keys=[position_key],
+            channel_names=["c0"],
+            shape=shape,
+            chunks=(1, 1, 4, 16, 16),
+            shards_ratio=shards_ratio,
+            version="0.5",
+        )
+    populate_store(input_store, [position_key], shape, np.float32)
+
+    apply_transform_to_tczyx_and_save(
+        func=dummy_transform,
+        input_position_path=input_store / Path(*position_key),
+        output_position_path=output_store / Path(*position_key),
+        input_channel_indices=[0],
+        output_channel_indices=[0],
+        input_time_indices=[0, 1],
+        output_time_indices=[0, 1],
+        constant=2,
+    )
+
+    with open_ome_zarr(input_store) as in_ds, open_ome_zarr(output_store) as out_ds:
+        in_slice = in_ds["/".join(position_key)].data[:2, :1]
+        out_slice = out_ds["/".join(position_key)].data[:2, :1]
+    np.testing.assert_array_almost_equal(out_slice, dummy_transform(in_slice, constant=2))

--- a/tests/ngff/test_ngff_utils.py
+++ b/tests/ngff/test_ngff_utils.py
@@ -281,7 +281,11 @@ def apply_transform_czyx_setup(draw):
     ) = draw(plate_setup())
     T, C = shape[:2]
 
-    # Define a helper strategy to generate channel indices based on C
+    # Define a helper strategy to generate channel indices based on C.
+    # Integer lists are drawn ``unique=True`` and sorted: zarrs only accelerates
+    # monotonically-increasing unique oindex selectors and falls back to the
+    # buggy BatchedCodecPipeline (zarr-python#2834 / iohub#404) for duplicate
+    # or unsorted inputs.
     channel_indices_strategy = st.one_of(
         st.builds(
             slice,
@@ -293,7 +297,8 @@ def apply_transform_czyx_setup(draw):
             st.integers(min_value=0, max_value=C - 1),
             min_size=1,
             max_size=min(3, C),
-        ),
+            unique=True,
+        ).map(sorted),
     )
 
     time_indices_strategy = st.one_of(
@@ -301,7 +306,8 @@ def apply_transform_czyx_setup(draw):
             st.integers(min_value=0, max_value=T - 1),
             min_size=1,
             max_size=min(3, T),
-        ),
+            unique=True,
+        ).map(sorted),
     )
 
     # Generate input and output channel indices based on C
@@ -357,7 +363,11 @@ def process_single_position_setup(draw):
 
     T, C = shape[:2]
 
-    # Define a helper strategy to generate channel indices based on C
+    # Define a helper strategy to generate channel indices based on C.
+    # Integer lists are drawn ``unique=True`` and sorted: zarrs only accelerates
+    # monotonically-increasing unique oindex selectors and falls back to the
+    # buggy BatchedCodecPipeline (zarr-python#2834 / iohub#404) for duplicate
+    # or unsorted inputs.
     channel_indices_strategy = st.one_of(
         st.none(),
         st.lists(
@@ -375,8 +385,8 @@ def process_single_position_setup(draw):
                 st.integers(min_value=0, max_value=C - 1),
                 min_size=1,
                 max_size=C,
-                # ensure each inner list has one element),
-            ),
+                unique=True,
+            ).map(sorted),
             min_size=1,
             max_size=min(3, C),
         ),
@@ -388,7 +398,8 @@ def process_single_position_setup(draw):
             st.integers(min_value=0, max_value=T - 1),
             min_size=1,
             max_size=min(3, T),
-        ),
+            unique=True,
+        ).map(sorted),
     )
 
     # Generate input and output channel indices based on C


### PR DESCRIPTION
Closes #401.

## What this changes

Version-specific chunk and shard defaults for `iohub.ngff.utils.create_empty_plate`, plus the test coverage to pin them down.

### `src/iohub/ngff/utils.py`

- **v0.5** (Zarr v3): default chunks = `(1, 1, 16, 256, 256)` clamped to `shape`; default `shards_ratio` yields a shard of `(1, 1, Z, Y, X)` — one shard per `(T, C)` slot, per the DCA spec referenced in #401.
- **v0.4** (Zarr v2): default chunks = `(1, 1, Z, Y, X)` with Z halved until the single-chunk byte size fits under `_V04_MAX_CHUNK_SIZE_BYTES` (500 MB). No sharding, as Zarr v2 has no sharding codec.
- Extracted the branching into `_default_chunks(shape, dtype, version)` and `_default_shards_ratio(shape, chunks)` helpers, and promoted the two tunables to module-level constants `_V05_DEFAULT_ZYX_CHUNKS` and `_V04_MAX_CHUNK_SIZE_BYTES`.
- Removed the `max_chunk_size_bytes` parameter from `create_empty_plate`; the 500 MB cap is now the module-level constant `_V04_MAX_CHUNK_SIZE_BYTES` and applies only to v0.4 chunks (v0.5 chunks are driven by the DCA spec, not a byte cap).
- Updated the docstring to describe the version-specific defaults.

### Breaking change?

Technically yes, but low blast radius. `create_empty_plate(..., max_chunk_size_bytes=...)` is no longer accepted — callers who passed it by keyword will get a `TypeError`. I confirmed that [waveorder](https://github.com/mehta-lab/waveorder) and [biahub](https://github.com/czbiohub-sf/biahub) — the two primary downstream consumers of this function — never set the parameter explicitly, so this change is a no-op for them. No other in-tree callers pass it either (`grep -R max_chunk_size_bytes` in iohub turns up no hits outside `utils.py`).

If we want to be strict about API stability we can keep `max_chunk_size_bytes` as a deprecated passthrough that overrides the constant for v0.4, but given the known downstream callsites don't touch it, removing it is cleaner.

### `tests/ngff/test_ngff_utils.py`

Added explicit tests that pin the defaults so regressions fail deterministically instead of depending on which examples hypothesis happens to draw:

- `test_v05_default_chunks` (parametrized) — asserts the DCA-aligned chunk shape, clamped to each axis.
- `test_v05_default_shards_cover_zyx` — one shard per `(T, C)` for divisible dims.
- `test_v05_default_shards_with_non_divisible_zyx` — shard still covers `Z/Y/X` when they're not multiples of the chunk size.
- `test_v05_explicit_shards_ratio_is_honored` — caller override wins.
- `test_v04_default_chunks_cover_full_zyx` / `test_v04_default_chunks_capped_by_byte_limit` — full-ZYX chunks; Z halves when the chunk would exceed the byte cap.
- `test_v04_default_has_no_sharding` — `arr.shards is None` on v0.4.
- `test_v04_rejects_explicit_shards_ratio` — raises on v0.4.
- `test_process_single_position_on_sharded_v05_store` — end-to-end round-trip through the default-sharded v0.5 layout.
- `test_apply_transform_to_tczyx_on_multi_time_shard` — direct `oindex` write with `shard_t > 1`. No `xfail`: if the write ever stops succeeding, this fires.

Tightened the hypothesis strategies (`apply_transform_czyx_setup`, `process_single_position_setup`) so integer `time_indices` / `channel_indices` are drawn `unique=True` and sorted via `.map(sorted)`. See the "Why hypothesis needed tightening" section below.

## Why hypothesis needed tightening

Before this change, the existing hypothesis-based tests (`test_apply_transform_to_tczyx_and_save` et al.) passed in CI under the new defaults but **only by luck**: `@settings(max_examples=5)` on each test meant CI drew 5 random examples per run, none of which happened to trip the failure. At `max_examples=200` the same tests failed reliably.

Root cause: the new v0.5 defaults make stores sharded, and the write path goes through `arr.oindex[...]`. iohub's active codec pipeline is `ZarrsCodecPipeline` (zarrs is a required dep), which handles most oindex patterns correctly — but it raises `UnsupportedVIndexingError` and falls back to the default `BatchedCodecPipeline` when an indexer is duplicate or unsorted. The fallback pipeline has an upstream bug in its sharding codec merge step: [zarr-developers/zarr-python#2834](https://github.com/zarr-developers/zarr-python/issues/2834).

Direct repro on a sharded v0.5 store under iohub's default config:

| Indexer pattern | Result |
| --- | --- |
| `oindex[[0, 1], [0]]` — unique, sorted | ✅ OK |
| `oindex[[0, 2], [0]]` — unique, non-contiguous but sorted | ✅ OK |
| `oindex[[0, 0], [0]]` — duplicates | ❌ fallback → zarr#2834 |
| `oindex[[1, 0, 2], [0]]` — unsorted | ❌ fallback → zarr#2834 |

The hypothesis strategy was generating duplicate / unsorted integer lists like `[0, 0]` and `[1, 0, 2]`. Real callers (`biahub`, the hybrid_scheme processing pipelines, etc.) always build sorted unique index lists, so the duplicate/unsorted draws weren't exercising a real use case — they were exercising a zarrs fallback path that wouldn't otherwise fire. Enforcing `unique=True` + `.map(sorted)` at the strategy level matches what callers pass and keeps the tests on the zarrs fast path.

## Verification

Full file:

```
pytest tests/ngff/test_ngff_utils.py
19 passed in 3.49s
```

Stress run (all three hypothesis-based tests, `max_examples=200` each, generate-only so the 600 draws are all fresh):

```
3 passed in 140.54s
```

No flakes, no `xfail`, and the new explicit tests fail loudly if any of the pinned defaults regress.

## Test plan

- [x] `tests/ngff/test_ngff_utils.py` passes at default settings
- [x] Hypothesis-based tests pass at `max_examples=200` (no duplicate/unsorted fallbacks)
- [x] v0.5 sharded write path round-trips correctly via `process_single_position`
- [x] v0.5 multi-time oindex write into a shared shard succeeds
- [x] v0.4 rejects `shards_ratio` and has `shards is None` by default
- [x] Confirmed no downstream callers (`waveorder`, `biahub`) pass `max_chunk_size_bytes`
- [x] Test in biahub processing pipeline on mantis v2

## Follow-up
Should we update and `Position.create_zeros` (and therefore `create_image` which calls `create_zeros`) with better chunk and shard defaults? Currently chunking defaults to (1, 1, Z, Y, X), even for v0.5 and don't use sharding by default for v0.5

Transferred to https://github.com/czbiohub-sf/iohub/issues/409

```python
    def create_zeros(
        self,
        name: str,
        shape: tuple[int, ...],
        dtype: DTypeLike,
        chunks: tuple[int, ...] | None = None,
        shards_ratio: tuple[int, ...] | None = None,
        transform: list[TransformationMeta] | None = None,
        check_shape: bool = True,
    ):
        """Create a new zero-filled image array in the position.
        ...
        """
        if not chunks:
            chunks = self._default_chunks(shape, 3)

        if check_shape:
            self._check_shape(shape)
        arr_handle = self._create_zarr_array(name, shape, dtype, chunks, shards_ratio)
        img_arr = ImageArray.from_handle(arr_handle, self._impl)
        self._create_image_meta(name, transform=transform)
        return img_arr

    @staticmethod
    def _default_chunks(shape, last_data_dims: int):
        chunks = shape[-min(last_data_dims, len(shape)) :]
        return pad_shape(chunks, target=len(shape))
```