### PR TITLE
fix: rename zarr entry-point group for pyproject schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ tensorstore = [
     "tensorstore>=0.1.64",
 ]
 
-[project.entry-points."iohub.zarr-implementations"]
+[project.entry-points."iohub.zarr_implementations"]
 zarr = "iohub.core.implementations.zarr_python:ZarrPythonImplementation"
 tensorstore = "iohub.core.implementations.tensorstore:TensorStoreImplementation"
 

--- a/src/iohub/core/implementations/__init__.py
+++ b/src/iohub/core/implementations/__init__.py
@@ -1,6 +1,6 @@
 """Zarr I/O implementation backends.
 
-Implementations are discovered via the ``iohub.zarr-implementations``
+Implementations are discovered via the ``iohub.zarr_implementations``
 entry point group. See :mod:`iohub.core.registry` for the discovery mechanism.
 
 For direct imports::

--- a/src/iohub/core/registry.py
+++ b/src/iohub/core/registry.py
@@ -42,7 +42,7 @@ def _discover() -> None:
                     exc_info=True,
                 )
         # Entrypoint plugins can override builtins
-        for ep in entry_points(group="iohub.zarr-implementations"):
+        for ep in entry_points(group="iohub.zarr_implementations"):
             try:
                 _IMPLEMENTATIONS[ep.name] = ep.load()
             except Exception as err:  # noqa: BLE001 — plugin loading may fail in many ways


### PR DESCRIPTION
## Summary
Renames the `[project.entry-points]` group from `iohub.zarr-implementations` to `iohub.zarr_implementations` and updates the registry to match.

## Why
The [SchemaStore pyproject.json](https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/pyproject.json) only allows `entry-points` group names matching `^\w+(\.\w+)*$` (dot-separated segments of word characters; hyphens are not allowed in a segment). Editors and tools that validate `pyproject.toml` against that schema (e.g. Taplo) reported: `Additional properties are not allowed ('iohub.zarr-implementations' was unexpected)`.

## Note
**Breaking change** for any external package that registered under the old group name. Update third-party `[project.entry-points."iohub.zarr-implementations"]` to `iohub.zarr_implementations`.


Made with [Cursor](https://cursor.com)