### PR TITLE
feat(tensorstore): expose recheck_cached_data on TensorStoreConfig

### DIFF
--- a/src/iohub/core/config.py
+++ b/src/iohub/core/config.py
@@ -34,7 +34,42 @@ class ZarrConfig(BaseModel):
 
 
 class TensorStoreConfig(BaseModel):
-    """Config for the TensorStore implementation."""
+    """Config for the TensorStore implementation.
+
+    Parameters
+    ----------
+    compressor : CompressorConfig
+        Default compressor settings used at array creation.
+    data_copy_concurrency : int
+        Concurrency limit for TensorStore's ``data_copy_concurrency``
+        resource, bounding threads used to copy data between buffers.
+    context : dict or None
+        Optional raw ``ts.Context`` options merged into the context built
+        from this config. Individual fields on this config take precedence.
+    file_io_concurrency : int or None
+        Concurrency limit for TensorStore's ``file_io_concurrency``
+        resource, bounding concurrent filesystem reads/writes. Useful to
+        raise on high-latency networked filesystems (e.g. NFS) where the
+        default (32) under-saturates the link.
+    file_io_sync : bool
+        Whether TensorStore issues ``fsync`` on writes.
+    file_io_locking : {"auto", "disabled"}
+        File-locking policy for the ``file`` kvstore driver.
+    cache_pool_bytes : int or None
+        Aggregate byte budget for TensorStore's chunk cache pool. ``None``
+        disables caching.
+    recheck_cached_data : bool, "open" or None
+        Controls whether cached chunk data is re-validated on each read.
+        ``None`` (default) uses the TensorStore driver default, which
+        revalidates cached metadata on every access — one stat/GETATTR per
+        chunk. ``"open"`` checks freshness only when the array is opened
+        and trusts the cache thereafter — recommended for long-running
+        read-heavy workloads on NFS/VAST where the underlying zarr files
+        do not change. ``False`` disables freshness checks entirely.
+    extra_context : dict or None
+        Additional raw ``ts.Context`` entries merged after all typed
+        fields, useful as an escape hatch for knobs not modeled here.
+    """
 
     compressor: CompressorConfig = Field(default_factory=CompressorConfig)
     data_copy_concurrency: int = Field(default=4, ge=1)
@@ -43,6 +78,7 @@ class TensorStoreConfig(BaseModel):
     file_io_sync: bool = True
     file_io_locking: Literal["auto", "disabled"] = "auto"
     cache_pool_bytes: int | None = None
+    recheck_cached_data: bool | Literal["open"] | None = None
     extra_context: dict | None = None
 
 

--- a/src/iohub/core/config.py
+++ b/src/iohub/core/config.py
@@ -38,23 +38,10 @@ class TensorStoreConfig(BaseModel):
 
     Parameters
     ----------
-    compressor : CompressorConfig
-        Default compressor settings used at array creation.
-    data_copy_concurrency : int
-        Concurrency limit for TensorStore's ``data_copy_concurrency``
-        resource, bounding threads used to copy data between buffers.
-    context : dict or None
-        Optional raw ``ts.Context`` options merged into the context built
-        from this config. Individual fields on this config take precedence.
     file_io_concurrency : int or None
         Concurrency limit for TensorStore's ``file_io_concurrency``
-        resource, bounding concurrent filesystem reads/writes. Useful to
-        raise on high-latency networked filesystems (e.g. NFS) where the
-        default (32) under-saturates the link.
-    file_io_sync : bool
-        Whether TensorStore issues ``fsync`` on writes.
-    file_io_locking : {"auto", "disabled"}
-        File-locking policy for the ``file`` kvstore driver.
+        resource. Raise above the default (32) on high-latency networked
+        filesystems (e.g. NFS) where the default under-saturates the link.
     cache_pool_bytes : int or None
         Aggregate byte budget for TensorStore's chunk cache pool. ``None``
         disables caching.
@@ -66,9 +53,6 @@ class TensorStoreConfig(BaseModel):
         and trusts the cache thereafter — recommended for long-running
         read-heavy workloads on NFS/VAST where the underlying zarr files
         do not change. ``False`` disables freshness checks entirely.
-    extra_context : dict or None
-        Additional raw ``ts.Context`` entries merged after all typed
-        fields, useful as an escape hatch for knobs not modeled here.
     """
 
     compressor: CompressorConfig = Field(default_factory=CompressorConfig)

--- a/src/iohub/core/implementations/tensorstore.py
+++ b/src/iohub/core/implementations/tensorstore.py
@@ -193,13 +193,15 @@ class TensorStoreImplementation(_TS_IMPL_BASE):
                 "driver": driver,
                 "kvstore": {"driver": "file", "path": key},
             }
-            self._array_cache[key] = _ts_open(
-                spec,
-                open=True,
-                read=True,
-                write=writable,
-                context=self._context(),
-            )
+            open_kwargs: dict[str, Any] = {
+                "open": True,
+                "read": True,
+                "write": writable,
+                "context": self._context(),
+            }
+            if self.config.recheck_cached_data is not None:
+                open_kwargs["recheck_cached_data"] = self.config.recheck_cached_data
+            self._array_cache[key] = _ts_open(spec, **open_kwargs)
         return self._array_cache[key]
 
     # -- Array I/O ---------------------------------------------------------

--- a/tests/ngff/test_ngff.py
+++ b/tests/ngff/test_ngff.py
@@ -553,6 +553,57 @@ def test_ome_zarr_to_tensorstore(channels_and_random_5d, arr_name, version, conc
             assert_array_equal(read_only[arr_name].numpy(), zeros)
 
 
+@pytest.mark.parametrize("recheck_cached_data", [None, "open", True, False])
+def test_tensorstore_recheck_cached_data(monkeypatch, recheck_cached_data):
+    """``TensorStoreConfig.recheck_cached_data`` propagates into ``ts.open``.
+
+    When the option is ``None`` (default) the kwarg must not be forwarded,
+    so the TensorStore driver falls back to its own default. For any other
+    value (``"open"``, ``True``, ``False``) the exact value must reach the
+    ``ts.open`` call — this is the knob used to suppress per-chunk
+    revalidation on networked filesystems during read-heavy training.
+    """
+    pytest.importorskip("tensorstore")
+    import tensorstore as ts
+
+    from iohub.core.config import TensorStoreConfig
+    from iohub.core.implementations import tensorstore as ts_impl
+
+    captured_kwargs: list[dict] = []
+    real_ts_open = ts_impl._ts_open
+
+    def spy_ts_open(spec, **kwargs):
+        captured_kwargs.append(kwargs)
+        return real_ts_open(spec, **kwargs)
+
+    monkeypatch.setattr(ts_impl, "_ts_open", spy_ts_open)
+
+    channel_names = ["DAPI"]
+    random_5d = np.random.default_rng(0).random((1, 1, 1, 4, 4), dtype=np.float32)
+    ts_config = TensorStoreConfig(recheck_cached_data=recheck_cached_data)
+
+    with _temp_ome_zarr(random_5d, channel_names, arr_name="0", version="0.5") as dataset:
+        store_path = Path(dataset.zgroup.store.root)
+        with open_ome_zarr(
+            store_path,
+            layout="fov",
+            mode="r",
+            implementation="tensorstore",
+            implementation_config=ts_config,
+        ) as ts_dataset:
+            handle = ts_dataset["0"].native
+            assert isinstance(handle, ts.TensorStore)
+            assert_array_equal(np.asarray(handle.read().result()), random_5d)
+
+    open_calls = [k for k in captured_kwargs if k.get("open") is True]
+    assert open_calls, "Expected at least one ts.open(open=True) call"
+    last = open_calls[-1]
+    if recheck_cached_data is None:
+        assert "recheck_cached_data" not in last
+    else:
+        assert last.get("recheck_cached_data") == recheck_cached_data
+
+
 @given(
     channels_and_random_5d=_channels_and_random_5d(),
     arr_name=short_alpha_numeric,

--- a/tests/ngff/test_ngff.py
+++ b/tests/ngff/test_ngff.py
@@ -553,57 +553,6 @@ def test_ome_zarr_to_tensorstore(channels_and_random_5d, arr_name, version, conc
             assert_array_equal(read_only[arr_name].numpy(), zeros)
 
 
-@pytest.mark.parametrize("recheck_cached_data", [None, "open", True, False])
-def test_tensorstore_recheck_cached_data(monkeypatch, recheck_cached_data):
-    """``TensorStoreConfig.recheck_cached_data`` propagates into ``ts.open``.
-
-    When the option is ``None`` (default) the kwarg must not be forwarded,
-    so the TensorStore driver falls back to its own default. For any other
-    value (``"open"``, ``True``, ``False``) the exact value must reach the
-    ``ts.open`` call — this is the knob used to suppress per-chunk
-    revalidation on networked filesystems during read-heavy training.
-    """
-    pytest.importorskip("tensorstore")
-    import tensorstore as ts
-
-    from iohub.core.config import TensorStoreConfig
-    from iohub.core.implementations import tensorstore as ts_impl
-
-    captured_kwargs: list[dict] = []
-    real_ts_open = ts_impl._ts_open
-
-    def spy_ts_open(spec, **kwargs):
-        captured_kwargs.append(kwargs)
-        return real_ts_open(spec, **kwargs)
-
-    monkeypatch.setattr(ts_impl, "_ts_open", spy_ts_open)
-
-    channel_names = ["DAPI"]
-    random_5d = np.random.default_rng(0).random((1, 1, 1, 4, 4), dtype=np.float32)
-    ts_config = TensorStoreConfig(recheck_cached_data=recheck_cached_data)
-
-    with _temp_ome_zarr(random_5d, channel_names, arr_name="0", version="0.5") as dataset:
-        store_path = Path(dataset.zgroup.store.root)
-        with open_ome_zarr(
-            store_path,
-            layout="fov",
-            mode="r",
-            implementation="tensorstore",
-            implementation_config=ts_config,
-        ) as ts_dataset:
-            handle = ts_dataset["0"].native
-            assert isinstance(handle, ts.TensorStore)
-            assert_array_equal(np.asarray(handle.read().result()), random_5d)
-
-    open_calls = [k for k in captured_kwargs if k.get("open") is True]
-    assert open_calls, "Expected at least one ts.open(open=True) call"
-    last = open_calls[-1]
-    if recheck_cached_data is None:
-        assert "recheck_cached_data" not in last
-    else:
-        assert last.get("recheck_cached_data") == recheck_cached_data
-
-
 @given(
     channels_and_random_5d=_channels_and_random_5d(),
     arr_name=short_alpha_numeric,


### PR DESCRIPTION
Add the `rechecked_cached_data` and fowrad the kward into _ts_open in open_array, when it's explicitly set. 
