### PR TITLE
feat: Added RFC-9 Zipped OME-Zarr

### DIFF
--- a/src/iohub/cli/cli.py
+++ b/src/iohub/cli/cli.py
@@ -5,12 +5,15 @@ import click
 from iohub import __version__, open_ome_zarr
 from iohub.cli.parsing import input_position_dirpaths
 from iohub.convert import TIFFConverter
+from iohub.core.ozx import pack_ozx, summarize_ozx
 from iohub.reader import print_info
 from iohub.rename_wells import rename_wells
 
 VERSION = __version__
 
 _DATASET_PATH = click.Path(exists=True, file_okay=False, resolve_path=True, path_type=pathlib.Path)
+# Like _DATASET_PATH but also accepts files (e.g. ``.ozx`` archives).
+_OME_ZARR_PATH = click.Path(exists=True, resolve_path=True, path_type=pathlib.Path)
 
 
 @click.group()
@@ -26,7 +29,7 @@ def cli():
     "files",
     nargs=-1,
     required=True,
-    type=_DATASET_PATH,
+    type=_OME_ZARR_PATH,
 )
 @click.option(
     "--verbose",
@@ -35,11 +38,11 @@ def cli():
     help="Show usage guide to open dataset in Python and full tree for HCS Plates in OME-Zarr",
 )
 def info(files, verbose):
-    """View basic metadata of a list of FILES.
+    """View metadata for one or more FILES.
 
-    Supported formats are Micro-Manager-acquired TIFF datasets
-    (single-page TIFF, multi-page OME-TIFF, NDTIFF)
-    and OME-Zarr (v0.1 linear HCS layout and all v0.4 layouts).
+    Supports Micro-Manager TIFF datasets (multi-page OME-TIFF, NDTIFF),
+    OME-Zarr directory stores (v0.4 and v0.5), and RFC-9 zipped
+    OME-Zarr archives (``.ozx``).
     """
     for file in files:
         click.echo(f"Reading file:\t {file}")
@@ -195,3 +198,91 @@ def rename_wells_command(zarrfile, csvfile):
     ```
     """
     rename_wells(zarrfile, csvfile)
+
+
+def _echo_ozx_summary(verb: str, path: pathlib.Path) -> None:
+    """Print the one-liner ``ozx pack`` shows on success."""
+    s = summarize_ozx(path)
+    click.echo(f"{verb}: {path}  (ome version={s.version}, jsonFirst={s.json_first})")
+
+
+@cli.group(name="ozx")
+@click.help_option("-h", "--help")
+def ozx_group():
+    """RFC-9 zipped OME-Zarr (``.ozx``) operations.
+
+    A ``.ozx`` is a single-file OME-Zarr archive (ZIP_STORED + ZIP64)
+    designed for distribution - S3, AWS Open Data, HPC↔compute-cluster
+    transfers - not as a live mutable store. One file to upload,
+    download, and serve.
+
+    Use ``ozx pack`` to bundle a directory store for export and
+    ``ozx info`` to inspect an archive's RFC-9 properties. ``iohub
+    info`` works on ``.ozx`` paths directly for the usual FOV summary.
+    """
+
+
+@ozx_group.command(name="pack")
+@click.help_option("-h", "--help")
+@click.option(
+    "-i",
+    "--input",
+    "src",
+    required=True,
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, resolve_path=True, path_type=pathlib.Path),
+    help="Input OME-Zarr directory store.",
+)
+@click.option(
+    "-o",
+    "--output",
+    "dst",
+    required=True,
+    type=click.Path(exists=False, resolve_path=True, path_type=pathlib.Path),
+    help="Output .ozx path (must not exist).",
+)
+@click.option(
+    "--version",
+    "ome_version",
+    default=None,
+    help="OME-NGFF version to record. Sniffed from source if omitted.",
+)
+def ozx_pack(src, dst, ome_version):
+    """Pack an OME-Zarr directory into an RFC-9 ``.ozx`` archive.
+
+    Writes a ZIP_STORED + ZIP64 archive in one pass with entries in BFS
+    order - root ``zarr.json`` first, other ``zarr.json`` next, chunks
+    last - and ``jsonFirst:true`` in the archive comment. HTTP-range
+    readers can then fetch all metadata in one contiguous Range request
+    on cold opens, the win that matters for S3 and AWS Open Data.
+    """
+    out = pack_ozx(src, dst, version=ome_version)
+    _echo_ozx_summary("packed", out)
+
+
+@ozx_group.command(name="info")
+@click.help_option("-h", "--help")
+@click.argument(
+    "path",
+    type=click.Path(exists=True, dir_okay=False, resolve_path=True, path_type=pathlib.Path),
+)
+def ozx_info(path):
+    """Print RFC-9 archive metadata: version, ``jsonFirst``, entry count, size.
+
+    Use it to sanity-check an archive before publishing (``jsonFirst``
+    should be ``True`` after ``iohub ozx pack``) or to inspect archives
+    received from collaborators or downloaded from public datasets.
+    """
+    import zipfile
+
+    # One zip open for the namelist, one for the comment.
+    with zipfile.ZipFile(path) as zf:
+        names = zf.namelist()
+    summary = summarize_ozx(path)
+    n_entries = len(names)
+    n_meta = sum(1 for n in names if n.rsplit("/", 1)[-1] == "zarr.json")
+    n_dupes = n_entries - len(set(names))
+    click.echo(f"path:        {path}")
+    click.echo(f"size:        {path.stat().st_size:,} bytes")
+    click.echo(f"entries:     {n_entries:,}  ({n_meta} zarr.json, {n_dupes} duplicate names)")
+    click.echo(f"ome version: {summary.version}")
+    click.echo(f"jsonFirst:   {summary.json_first}")

--- a/src/iohub/cli/cli.py
+++ b/src/iohub/cli/cli.py
@@ -5,7 +5,7 @@ import click
 from iohub import __version__, open_ome_zarr
 from iohub.cli.parsing import input_position_dirpaths
 from iohub.convert import TIFFConverter
-from iohub.core.ozx import pack_ozx, summarize_ozx
+from iohub.core.ozx import is_ozx_path, pack_ozx, unpack_ozx
 from iohub.reader import print_info
 from iohub.rename_wells import rename_wells
 
@@ -55,49 +55,65 @@ def info(files, verbose):
     "--input",
     "-i",
     required=True,
-    type=_DATASET_PATH,
-    help="Input Micro-Manager TIFF dataset directory",
+    type=_OME_ZARR_PATH,
+    help="Input dataset: Micro-Manager TIFF dir, OME-Zarr dir, or RFC-9 .ozx archive.",
 )
 @click.option(
     "--output",
     "-o",
     required=True,
-    type=click.Path(exists=False, resolve_path=True),
-    help="Output zarr store (/**/converted.zarr)",
+    type=click.Path(exists=False, resolve_path=True, path_type=pathlib.Path),
+    help="Output path. Suffix selects the operation: .zarr (Zarr dir) or .ozx (zipped).",
 )
 @click.option(
     "--grid-layout",
     "-g",
     required=False,
     is_flag=True,
-    help="Arrange FOVs in a row/column grid layout for tiled acquisition",
+    help="(TIFF → Zarr only) Arrange FOVs in a row/column grid layout.",
 )
 @click.option(
     "--chunks",
     "-c",
     required=False,
     default="XYZ",
-    help="Zarr chunk size given as 'XY', 'XYZ', or a tuple of chunk "
-    "dimensions. If 'XYZ', chunk size will be limited to 500 MB.",
+    help="(TIFF → Zarr only) Zarr chunk size: 'XY', 'XYZ', or a tuple. 'XYZ' caps at 500 MB.",
 )
 @click.option(
     "--ome-zarr-version",
     "-v",
     required=False,
-    default="0.4",
+    default=None,
     type=click.Choice(["0.4", "0.5"]),
-    help="OME-NGFF version for the output Zarr store. '0.4' uses Zarr v2 format; '0.5' uses Zarr v3 format.",
+    help="OME-NGFF version. TIFF default: 0.4. Pack: sniffed from source if omitted.",
 )
 def convert(input, output, grid_layout, chunks, ome_zarr_version):
-    """Converts Micro-Manager TIFF datasets to OME-Zarr"""
-    converter = TIFFConverter(
-        input_dir=input,
-        output_dir=output,
+    """Convert datasets between supported formats.
+
+    Routes by suffix: a TIFF directory plus a ``.zarr`` output runs the
+    Micro-Manager TIFF → OME-Zarr converter; a ``.zarr`` source plus a
+    ``.ozx`` output packs an RFC-9 zip archive; a ``.ozx`` source plus
+    a ``.zarr`` output unpacks back to a directory store.
+    """
+    src = pathlib.Path(input)
+    dst = pathlib.Path(output)
+
+    if is_ozx_path(dst):
+        out = pack_ozx(src, dst, version=ome_zarr_version)
+        click.echo(f"packed: {out}")
+        return
+    if is_ozx_path(src):
+        out = unpack_ozx(src, dst)
+        click.echo(f"unpacked: {out}")
+        return
+    # Default: TIFF → OME-Zarr (TIFFConverter sniffs the input format).
+    TIFFConverter(
+        input_dir=src,
+        output_dir=dst,
         grid_layout=grid_layout,
         chunks=chunks,
-        version=ome_zarr_version,
-    )
-    converter()
+        version=ome_zarr_version or "0.4",
+    )()
 
 
 @cli.command()
@@ -198,91 +214,3 @@ def rename_wells_command(zarrfile, csvfile):
     ```
     """
     rename_wells(zarrfile, csvfile)
-
-
-def _echo_ozx_summary(verb: str, path: pathlib.Path) -> None:
-    """Print the one-liner ``ozx pack`` shows on success."""
-    s = summarize_ozx(path)
-    click.echo(f"{verb}: {path}  (ome version={s.version}, jsonFirst={s.json_first})")
-
-
-@cli.group(name="ozx")
-@click.help_option("-h", "--help")
-def ozx_group():
-    """RFC-9 zipped OME-Zarr (``.ozx``) operations.
-
-    A ``.ozx`` is a single-file OME-Zarr archive (ZIP_STORED + ZIP64)
-    designed for distribution - S3, AWS Open Data, HPC↔compute-cluster
-    transfers - not as a live mutable store. One file to upload,
-    download, and serve.
-
-    Use ``ozx pack`` to bundle a directory store for export and
-    ``ozx info`` to inspect an archive's RFC-9 properties. ``iohub
-    info`` works on ``.ozx`` paths directly for the usual FOV summary.
-    """
-
-
-@ozx_group.command(name="pack")
-@click.help_option("-h", "--help")
-@click.option(
-    "-i",
-    "--input",
-    "src",
-    required=True,
-    type=click.Path(exists=True, file_okay=False, dir_okay=True, resolve_path=True, path_type=pathlib.Path),
-    help="Input OME-Zarr directory store.",
-)
-@click.option(
-    "-o",
-    "--output",
-    "dst",
-    required=True,
-    type=click.Path(exists=False, resolve_path=True, path_type=pathlib.Path),
-    help="Output .ozx path (must not exist).",
-)
-@click.option(
-    "--version",
-    "ome_version",
-    default=None,
-    help="OME-NGFF version to record. Sniffed from source if omitted.",
-)
-def ozx_pack(src, dst, ome_version):
-    """Pack an OME-Zarr directory into an RFC-9 ``.ozx`` archive.
-
-    Writes a ZIP_STORED + ZIP64 archive in one pass with entries in BFS
-    order - root ``zarr.json`` first, other ``zarr.json`` next, chunks
-    last - and ``jsonFirst:true`` in the archive comment. HTTP-range
-    readers can then fetch all metadata in one contiguous Range request
-    on cold opens, the win that matters for S3 and AWS Open Data.
-    """
-    out = pack_ozx(src, dst, version=ome_version)
-    _echo_ozx_summary("packed", out)
-
-
-@ozx_group.command(name="info")
-@click.help_option("-h", "--help")
-@click.argument(
-    "path",
-    type=click.Path(exists=True, dir_okay=False, resolve_path=True, path_type=pathlib.Path),
-)
-def ozx_info(path):
-    """Print RFC-9 archive metadata: version, ``jsonFirst``, entry count, size.
-
-    Use it to sanity-check an archive before publishing (``jsonFirst``
-    should be ``True`` after ``iohub ozx pack``) or to inspect archives
-    received from collaborators or downloaded from public datasets.
-    """
-    import zipfile
-
-    # One zip open for the namelist, one for the comment.
-    with zipfile.ZipFile(path) as zf:
-        names = zf.namelist()
-    summary = summarize_ozx(path)
-    n_entries = len(names)
-    n_meta = sum(1 for n in names if n.rsplit("/", 1)[-1] == "zarr.json")
-    n_dupes = n_entries - len(set(names))
-    click.echo(f"path:        {path}")
-    click.echo(f"size:        {path.stat().st_size:,} bytes")
-    click.echo(f"entries:     {n_entries:,}  ({n_meta} zarr.json, {n_dupes} duplicate names)")
-    click.echo(f"ome version: {summary.version}")
-    click.echo(f"jsonFirst:   {summary.json_first}")

--- a/src/iohub/cli/cli.py
+++ b/src/iohub/cli/cli.py
@@ -97,12 +97,25 @@ def convert(input, output, grid_layout, chunks, ome_zarr_version):
     """
     src = pathlib.Path(input)
     dst = pathlib.Path(output)
+    tiff_only = grid_layout or chunks != "XYZ"
 
     if is_ozx_path(dst):
+        # Pack: 1:1 file copy preserving source chunks. Re-chunking would
+        # mean a full read+rewrite — a different operation, out of scope.
+        if tiff_only:
+            raise click.BadParameter(
+                "--grid-layout and --chunks apply only to TIFF → Zarr conversion. "
+                "Pack copies chunks 1:1 from the source."
+            )
         out = pack_ozx(src, dst, version=ome_zarr_version)
         click.echo(f"packed: {out}")
         return
     if is_ozx_path(src):
+        # Unpack: archive structure dictates everything; no flags apply.
+        if tiff_only or ome_zarr_version is not None:
+            raise click.BadParameter(
+                "--grid-layout, --chunks, and --ome-zarr-version do not apply to .ozx → .zarr unpack."
+            )
         out = unpack_ozx(src, dst)
         click.echo(f"unpacked: {out}")
         return

--- a/src/iohub/core/__init__.py
+++ b/src/iohub/core/__init__.py
@@ -15,6 +15,18 @@ from iohub.core.errors import (
     PathNormalizationError,
     StoreOpenError,
 )
+from iohub.core.ozx import (
+    OZX_EXTENSION,
+    OzxStore,
+    OzxSummary,
+    is_ozx_path,
+    pack_ozx,
+    read_ozx_comment,
+    read_ozx_json_first,
+    read_ozx_version,
+    summarize_ozx,
+    write_ozx_comment,
+)
 from iohub.core.protocol import (
     ArrayBackend,
     ArrayIO,
@@ -37,6 +49,7 @@ from iohub.core.types import (
 from iohub.core.utils import normalize_path, pad_shape
 
 __all__ = [
+    "OZX_EXTENSION",
     # Types
     "AccessMode",
     "ArrayBackend",
@@ -55,6 +68,9 @@ __all__ = [
     # Arrays
     "NGFFArray",
     "NGFFVersion",
+    # OZX (RFC-9 zipped OME-Zarr)
+    "OzxStore",
+    "OzxSummary",
     "PathNormalizationError",
     "StoreOpenError",
     "StorePath",
@@ -65,12 +81,19 @@ __all__ = [
     # Registry
     "available_implementations",
     "get_implementation",
+    "is_ozx_path",
     "ngff_version_for_format",
     # Utils
     "normalize_path",
+    "pack_ozx",
     "pad_shape",
+    "read_ozx_comment",
+    "read_ozx_json_first",
+    "read_ozx_version",
     "register_implementation",
     "set_default_implementation",
+    "summarize_ozx",
+    "write_ozx_comment",
     # Compat
     "zarr_format_for_version",
 ]

--- a/src/iohub/core/__init__.py
+++ b/src/iohub/core/__init__.py
@@ -21,11 +21,9 @@ from iohub.core.ozx import (
     OzxSummary,
     is_ozx_path,
     pack_ozx,
-    read_ozx_comment,
-    read_ozx_json_first,
     read_ozx_version,
     summarize_ozx,
-    write_ozx_comment,
+    unpack_ozx,
 )
 from iohub.core.protocol import (
     ArrayBackend,
@@ -87,13 +85,11 @@ __all__ = [
     "normalize_path",
     "pack_ozx",
     "pad_shape",
-    "read_ozx_comment",
-    "read_ozx_json_first",
     "read_ozx_version",
     "register_implementation",
     "set_default_implementation",
     "summarize_ozx",
-    "write_ozx_comment",
+    "unpack_ozx",
     # Compat
     "zarr_format_for_version",
 ]

--- a/src/iohub/core/ozx.py
+++ b/src/iohub/core/ozx.py
@@ -1,0 +1,299 @@
+"""RFC-9 (Zipped OME-Zarr, ``.ozx``) support — a thin layer over ``zarr.storage.ZipStore``.
+
+Adds on top of zarr-python's ``ZipStore``:
+
+1. ``OzxStore`` — RFC-9 defaults (``ZIP_STORED``, ``allowZip64=True``) and
+   writes the archive comment on close.
+2. Comment helpers — read and write the ``{"ome": {"version": ..., "zipFile": ...}}`` JSON.
+3. ``pack_ozx`` — emit a BFS-ordered archive from a directory store, satisfying
+   the RFC-9 SHOULD ordering clause in one pass.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import zipfile
+from collections.abc import Callable, Iterable
+from pathlib import Path
+from typing import IO, Literal, NamedTuple
+
+from zarr.storage import ZipStore
+
+from iohub.core.compat import get_ome_attrs
+
+_logger = logging.getLogger(__name__)
+
+OZX_EXTENSION = ".ozx"
+
+# 1 MiB: bounds peak memory on sharded archives where a single chunk
+# can be hundreds of MB.
+_COPY_BUFFER_BYTES = 1 << 20
+
+_OME = "ome"
+_VERSION = "version"
+_ZIP_FILE = "zipFile"
+_CENTRAL_DIRECTORY = "centralDirectory"
+_JSON_FIRST = "jsonFirst"
+
+
+def is_ozx_path(path: str | Path) -> bool:
+    """Return True when ``path`` ends with ``.ozx``.
+
+    Parameters
+    ----------
+    path : str | Path
+        Path to check; existence not required.
+    """
+    return Path(path).suffix.lower() == OZX_EXTENSION
+
+
+def _build_comment(version: str, *, json_first: bool = False) -> bytes:
+    ome: dict = {_VERSION: str(version)}
+    if json_first:
+        ome[_ZIP_FILE] = {_CENTRAL_DIRECTORY: {_JSON_FIRST: True}}
+    return json.dumps({_OME: ome}, separators=(",", ":")).encode("utf-8")
+
+
+def _parse_comment(raw: bytes) -> dict | None:
+    if not raw:
+        return None
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        _logger.warning("OZX archive comment is not valid UTF-8 JSON; ignoring.")
+        return None
+
+
+def _comment_version(comment: dict | None) -> str | None:
+    return get_ome_attrs(comment or {}).get(_VERSION)
+
+
+def _comment_json_first(comment: dict | None) -> bool:
+    return bool(get_ome_attrs(comment or {}).get(_ZIP_FILE, {}).get(_CENTRAL_DIRECTORY, {}).get(_JSON_FIRST, False))
+
+
+def read_ozx_comment(path: str | Path) -> dict | None:
+    """Return the parsed RFC-9 archive comment, or ``None`` if absent or invalid.
+
+    Parameters
+    ----------
+    path : str | Path
+        ``.ozx`` archive to read.
+    """
+    with zipfile.ZipFile(path, mode="r") as zf:
+        return _parse_comment(zf.comment)
+
+
+def read_ozx_version(path: str | Path) -> str | None:
+    """Return the OME-NGFF version advertised in the archive comment.
+
+    Parameters
+    ----------
+    path : str | Path
+        ``.ozx`` archive to read.
+    """
+    return _comment_version(read_ozx_comment(path))
+
+
+def read_ozx_json_first(path: str | Path) -> bool:
+    """Return the ``jsonFirst`` ordering hint (defaults to ``False``).
+
+    Parameters
+    ----------
+    path : str | Path
+        ``.ozx`` archive to read.
+    """
+    return _comment_json_first(read_ozx_comment(path))
+
+
+class OzxSummary(NamedTuple):
+    """RFC-9 attributes carried in an ``.ozx`` archive comment."""
+
+    version: str | None
+    json_first: bool
+
+
+def summarize_ozx(path: str | Path) -> OzxSummary:
+    """Read all RFC-9 attributes in one zip open.
+
+    Prefer this when you need both the version and ``jsonFirst`` —
+    one open instead of two.
+
+    Parameters
+    ----------
+    path : str | Path
+        ``.ozx`` archive to inspect.
+    """
+    comment = read_ozx_comment(path)
+    return OzxSummary(_comment_version(comment), _comment_json_first(comment))
+
+
+def write_ozx_comment(
+    path: str | Path,
+    *,
+    version: str,
+    json_first: bool = False,
+) -> None:
+    """Set the RFC-9 archive comment on an existing zip file.
+
+    Use this to patch archives not written through ``OzxStore``.
+
+    Parameters
+    ----------
+    path : str | Path
+        Existing zip file to patch.
+    version : str
+        OME-NGFF version to record.
+    json_first : bool
+        True if all ``zarr.json`` entries precede chunks in BFS order.
+    """
+    # ``mode="a"`` rewrites the central directory on close — the cheap
+    # way to update the comment without touching entry data.
+    with zipfile.ZipFile(path, mode="a") as zf:
+        zf.comment = _build_comment(version, json_first=json_first)
+
+
+class OzxStore(ZipStore):
+    """RFC-9 (Zipped OME-Zarr) store.
+
+    A :class:`zarr.storage.ZipStore` subclass with RFC-9 defaults:
+    ``ZIP_STORED`` (Zarr codecs handle compression), ``allowZip64=True``
+    (regardless of size), and the archive comment written on ``close()``.
+
+    The store writes entries in zarr's creation order and leaves
+    ``jsonFirst`` unset. For a SHOULD-compliant archive ready for
+    HTTP-range publishing, write to a directory store first and run
+    :func:`pack_ozx`.
+    """
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        mode: Literal["r", "w", "a"] = "r",
+        read_only: bool | None = None,
+        ome_version: str = "0.5",
+        allowZip64: bool = True,
+        compression: int = zipfile.ZIP_STORED,
+    ) -> None:
+        super().__init__(
+            path,
+            mode=mode,
+            read_only=read_only,
+            compression=compression,
+            allowZip64=allowZip64,
+        )
+        self._ome_version = str(ome_version)
+
+    def close(self) -> None:
+        """Write the RFC-9 archive comment (if writable) then close."""
+        # ZipStore opens lazily via ``_sync_open``; ``_zf``/``_lock`` only
+        # exist after first use. The ``_is_open`` guard handles untouched
+        # stores — writers that exited before any key write.
+        if not self._is_open:
+            return
+        if not self.read_only:
+            try:
+                self._zf.comment = _build_comment(self._ome_version)
+            except Exception as err:  # noqa: BLE001 — never block close on comment failure
+                _logger.warning("Failed to write OZX archive comment: %s", err)
+        super().close()
+
+
+def _bfs_order(names: Iterable[str]) -> list[str]:
+    """Order ``names`` for RFC-9 SHOULD compliance.
+
+    All ``zarr.json`` entries first, sorted by depth then name (root
+    sorts first because it sits at depth 0). Other entries keep their
+    input order.
+    """
+    meta: list[tuple[int, str]] = []
+    chunks: list[str] = []
+    for name in names:
+        if name.rsplit("/", 1)[-1] == "zarr.json":
+            meta.append((name.count("/"), name))
+        else:
+            chunks.append(name)
+    meta.sort()
+    return [name for _, name in meta] + chunks
+
+
+def _write_ozx_archive(
+    out_path: Path,
+    ordered: list[str],
+    *,
+    version: str,
+    open_member: Callable[[str], IO[bytes]],
+) -> None:
+    """Write an RFC-9 ``.ozx`` to ``out_path`` from a callable entry source.
+
+    Owns the destination ``ZipFile``, the archive comment, and the
+    unlink-on-failure cleanup.
+    """
+    try:
+        with zipfile.ZipFile(
+            out_path,
+            mode="w",
+            compression=zipfile.ZIP_STORED,
+            allowZip64=True,
+        ) as zout:
+            for arcname in ordered:
+                with open_member(arcname) as src_f, zout.open(arcname, mode="w") as dst_f:
+                    shutil.copyfileobj(src_f, dst_f, length=_COPY_BUFFER_BYTES)
+            zout.comment = _build_comment(version, json_first=True)
+    except Exception:
+        if out_path.exists():
+            out_path.unlink()
+        raise
+
+
+def pack_ozx(
+    src: str | Path,
+    dst: str | Path,
+    *,
+    version: str | None = None,
+) -> Path:
+    """Pack an OME-Zarr directory store into an RFC-9 ``.ozx`` archive.
+
+    Writes entries in BFS order with ``jsonFirst:true`` — fully
+    SHOULD-compliant in one pass.
+
+    Parameters
+    ----------
+    src : str | Path
+        OME-Zarr directory store.
+    dst : str | Path
+        Output ``.ozx`` path; must not exist.
+    version : str | None
+        OME-NGFF version for the archive comment. Sniffs from ``src``
+        when omitted.
+
+    Returns
+    -------
+    Path
+        Path of the written archive.
+    """
+    src_path = Path(src)
+    if not src_path.is_dir():
+        raise NotADirectoryError(f"pack source must be a directory: {src_path}")
+    out_path = Path(dst)
+    if out_path.exists():
+        raise FileExistsError(out_path)
+
+    if version is None:
+        # Local import: ``iohub`` re-exports from ``iohub.core``, which
+        # would create a cycle at module load.
+        from iohub import open_ome_zarr
+
+        with open_ome_zarr(src_path, mode="r") as node:
+            version = node.version
+
+    files = [p for p in src_path.rglob("*") if p.is_file()]
+    rel_names = [str(p.relative_to(src_path)).replace("\\", "/") for p in files]
+    by_name = dict(zip(rel_names, files, strict=True))
+    ordered = _bfs_order(rel_names)
+
+    _write_ozx_archive(out_path, ordered, version=version, open_member=lambda name: by_name[name].open("rb"))
+    return out_path

--- a/src/iohub/core/ozx.py
+++ b/src/iohub/core/ozx.py
@@ -2,22 +2,24 @@
 
 Adds on top of zarr-python's ``ZipStore``:
 
-1. ``OzxStore`` — RFC-9 defaults (``ZIP_STORED``, ``allowZip64=True``) and
-   writes the archive comment on close.
+1. ``OzxStore`` — RFC-9 defaults (``ZIP_STORED``, ``allowZip64=True``),
+   writes the archive comment on close, fork-safe via ``os.register_at_fork``.
 2. Comment helpers — read and write the ``{"ome": {"version": ..., "zipFile": ...}}`` JSON.
-3. ``pack_ozx`` — emit a BFS-ordered archive from a directory store, satisfying
-   the RFC-9 SHOULD ordering clause in one pass.
+3. ``pack_ozx`` / ``unpack_ozx`` — convert directory stores ↔ archives.
+   Pack writes BFS-ordered entries with ``jsonFirst:true`` in one pass.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import os
 import shutil
+import weakref
 import zipfile
 from collections.abc import Callable, Iterable
 from pathlib import Path
-from typing import IO, Literal, NamedTuple
+from typing import IO, Literal, NamedTuple, override
 
 from zarr.storage import ZipStore
 
@@ -41,12 +43,14 @@ _JSON_FIRST = "jsonFirst"
 def is_ozx_path(path: str | Path) -> bool:
     """Return True when ``path`` ends with ``.ozx``.
 
+    Case-sensitive to match Zarr's ``.zarr`` precedent within iohub.
+
     Parameters
     ----------
     path : str | Path
         Path to check; existence not required.
     """
-    return Path(path).suffix.lower() == OZX_EXTENSION
+    return Path(path).suffix == OZX_EXTENSION
 
 
 def _build_comment(version: str, *, json_first: bool = False) -> bytes:
@@ -66,22 +70,8 @@ def _parse_comment(raw: bytes) -> dict | None:
         return None
 
 
-def _comment_version(comment: dict | None) -> str | None:
-    return get_ome_attrs(comment or {}).get(_VERSION)
-
-
-def _comment_json_first(comment: dict | None) -> bool:
-    return bool(get_ome_attrs(comment or {}).get(_ZIP_FILE, {}).get(_CENTRAL_DIRECTORY, {}).get(_JSON_FIRST, False))
-
-
-def read_ozx_comment(path: str | Path) -> dict | None:
-    """Return the parsed RFC-9 archive comment, or ``None`` if absent or invalid.
-
-    Parameters
-    ----------
-    path : str | Path
-        ``.ozx`` archive to read.
-    """
+def _read_ozx_comment(path: str | Path) -> dict | None:
+    """Return the parsed RFC-9 archive comment, or ``None`` if absent or invalid."""
     with zipfile.ZipFile(path, mode="r") as zf:
         return _parse_comment(zf.comment)
 
@@ -94,43 +84,44 @@ def read_ozx_version(path: str | Path) -> str | None:
     path : str | Path
         ``.ozx`` archive to read.
     """
-    return _comment_version(read_ozx_comment(path))
-
-
-def read_ozx_json_first(path: str | Path) -> bool:
-    """Return the ``jsonFirst`` ordering hint (defaults to ``False``).
-
-    Parameters
-    ----------
-    path : str | Path
-        ``.ozx`` archive to read.
-    """
-    return _comment_json_first(read_ozx_comment(path))
+    return get_ome_attrs(_read_ozx_comment(path) or {}).get(_VERSION)
 
 
 class OzxSummary(NamedTuple):
-    """RFC-9 attributes carried in an ``.ozx`` archive comment."""
+    """Combined RFC-9 metadata + entry counts read from a ``.ozx``."""
 
     version: str | None
     json_first: bool
+    n_entries: int
+    n_zarr_json: int
+    n_duplicates: int
 
 
 def summarize_ozx(path: str | Path) -> OzxSummary:
-    """Read all RFC-9 attributes in one zip open.
+    """Read all RFC-9 attributes plus entry counts in one zip open.
 
-    Prefer this when you need both the version and ``jsonFirst`` —
-    one open instead of two.
+    Opens the archive once and pulls the comment plus ``namelist`` while
+    the file is open. ``zipfile.BadZipFile`` propagates so corrupt
+    central directories surface explicitly instead of being masked as
+    ``n_entries=0``.
 
     Parameters
     ----------
     path : str | Path
         ``.ozx`` archive to inspect.
     """
-    comment = read_ozx_comment(path)
-    return OzxSummary(_comment_version(comment), _comment_json_first(comment))
+    with zipfile.ZipFile(path, mode="r") as zf:
+        comment = _parse_comment(zf.comment)
+        names = zf.namelist()
+    ome = get_ome_attrs(comment or {})
+    version = ome.get(_VERSION)
+    json_first = bool(ome.get(_ZIP_FILE, {}).get(_CENTRAL_DIRECTORY, {}).get(_JSON_FIRST, False))
+    n_zarr_json = sum(1 for n in names if n.rsplit("/", 1)[-1] == "zarr.json")
+    n_duplicates = len(names) - len(set(names))
+    return OzxSummary(version, json_first, len(names), n_zarr_json, n_duplicates)
 
 
-def write_ozx_comment(
+def _write_ozx_comment(
     path: str | Path,
     *,
     version: str,
@@ -166,7 +157,28 @@ class OzxStore(ZipStore):
     ``jsonFirst`` unset. For a SHOULD-compliant archive ready for
     HTTP-range publishing, write to a directory store first and run
     :func:`pack_ozx`.
+
+    Fork-safe: an ``os.register_at_fork`` hook invalidates the
+    inherited ``ZipFile`` fd in child processes, so each child opens
+    its own. Spawn-safe via ``ZipStore.__getstate__``/``__setstate__``.
     """
+
+    # Identity-keyed live-instance registry. ``ZipStore`` defines
+    # ``__eq__`` (path equality) without ``__hash__``, so ``OzxStore``
+    # is unhashable; ``id(self)`` sidesteps that and the eq/hash
+    # contract violation a ``__hash__`` override would introduce.
+    _live_instances: weakref.WeakValueDictionary[int, OzxStore] = weakref.WeakValueDictionary()
+
+    @classmethod
+    def _invalidate_all_after_fork(cls) -> None:
+        """Drop the inherited ``ZipFile`` fd on every live instance.
+
+        Called by the module-level ``os.register_at_fork`` hook in each
+        forked child so the child re-opens the archive on first read
+        instead of sharing the parent's fd.
+        """
+        for store in list(cls._live_instances.values()):
+            store.invalidate_after_fork()
 
     def __init__(
         self,
@@ -186,7 +198,11 @@ class OzxStore(ZipStore):
             allowZip64=allowZip64,
         )
         self._ome_version = str(ome_version)
+        # Track this instance so the at-fork hook can invalidate its
+        # inherited fd in any child process.
+        type(self)._live_instances[id(self)] = self
 
+    @override
     def close(self) -> None:
         """Write the RFC-9 archive comment (if writable) then close."""
         # ZipStore opens lazily via ``_sync_open``; ``_zf``/``_lock`` only
@@ -200,6 +216,22 @@ class OzxStore(ZipStore):
             except Exception as err:  # noqa: BLE001 — never block close on comment failure
                 _logger.warning("Failed to write OZX archive comment: %s", err)
         super().close()
+
+    def invalidate_after_fork(self) -> None:
+        """Drop the inherited ``ZipFile`` fd after a ``fork()``.
+
+        Called by the module-level ``os.register_at_fork`` hook in every
+        forked child so that the child re-opens the archive on its first
+        read instead of sharing the parent's fd. No-op if the store has
+        not been opened yet.
+        """
+        self._is_open = False
+
+
+# Registration runs at module import; POSIX only. Windows has no fork,
+# and spawn workers re-open via ``ZipStore.__getstate__``/``__setstate__``.
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=OzxStore._invalidate_all_after_fork)
 
 
 def _bfs_order(names: Iterable[str]) -> list[str]:
@@ -296,4 +328,59 @@ def pack_ozx(
     ordered = _bfs_order(rel_names)
 
     _write_ozx_archive(out_path, ordered, version=version, open_member=lambda name: by_name[name].open("rb"))
+    return out_path
+
+
+def unpack_ozx(src: str | Path, dst: str | Path) -> Path:
+    """Unpack an RFC-9 ``.ozx`` archive into an OME-Zarr directory store.
+
+    Walks the archive, dedupes shadow ``zarr.json`` entries (last-wins,
+    matching ``ZipFile.read``), and writes each entry as a file under
+    ``dst``. Reverse of :func:`pack_ozx`.
+
+    Parameters
+    ----------
+    src : str | Path
+        Existing ``.ozx`` archive.
+    dst : str | Path
+        Output directory; must not exist.
+
+    Returns
+    -------
+    Path
+        Path of the written directory store.
+    """
+    src_path = Path(src)
+    if not src_path.is_file():
+        raise FileNotFoundError(f"unpack source must be a file: {src_path}")
+    out_path = Path(dst)
+    if out_path.exists():
+        raise FileExistsError(out_path)
+
+    out_path.mkdir(parents=True)
+    try:
+        with zipfile.ZipFile(src_path, mode="r") as zin:
+            # Dedupe by keeping the last ZipInfo per name — matches
+            # ZipFile.read semantics for archives with shadow entries.
+            infos: dict[str, zipfile.ZipInfo] = {info.filename: info for info in zin.infolist()}
+            for name, info in infos.items():
+                # Skip directory entries (``name/`` with empty content)
+                # that some zip tools (7z, info-zip) emit. They'd
+                # otherwise be written as regular files at the directory
+                # path and break sibling entry creation.
+                if name.endswith("/"):
+                    continue
+                # Refuse traversal: zip entries with .. or absolute paths
+                # could write outside dst. zipfile's extract() does this
+                # by default; we replicate the guard since we resolve
+                # paths manually.
+                target = (out_path / name).resolve()
+                if not target.is_relative_to(out_path.resolve()):
+                    raise ValueError(f"unsafe entry path escapes destination: {name!r}")
+                target.parent.mkdir(parents=True, exist_ok=True)
+                with zin.open(info, mode="r") as src_f, target.open("wb") as dst_f:
+                    shutil.copyfileobj(src_f, dst_f, length=_COPY_BUFFER_BYTES)
+    except Exception:
+        shutil.rmtree(out_path, ignore_errors=True)
+        raise
     return out_path

--- a/src/iohub/ngff/nodes.py
+++ b/src/iohub/ngff/nodes.py
@@ -26,9 +26,10 @@ from numpy.typing import ArrayLike, DTypeLike, NDArray
 from pydantic import ValidationError
 
 from iohub.core import ArraySpec, NGFFArray, get_implementation
-from iohub.core.compat import get_ome_attrs
+from iohub.core.compat import get_ome_attrs, zarr_format_for_version
 from iohub.core.config import ImplementationConfig
 from iohub.core.errors import StoreOpenError
+from iohub.core.ozx import OzxStore, is_ozx_path, read_ozx_version
 from iohub.core.protocol import ZarrImplementation
 from iohub.core.types import StorePath
 from iohub.core.utils import normalize_path, pad_shape
@@ -89,17 +90,57 @@ def _open_store(
         _logger.warning(
             f"IOHub is only tested against OME-NGFF v0.4 and v0.5. Requested version {version} may not work properly."
         )
+    # RFC-9 (.ozx): wrap the filesystem path in an OzxStore before handing
+    # it to the zarr implementation so the archive comment is written and
+    # RFC-9 defaults (ZIP_STORED, ZIP64) are applied.
+    if is_fs and is_ozx_path(store_path):
+        store_path, version = _open_ozx_store(store_path, mode, version, implementation)
+        is_fs = False  # downstream sees a Store, not a filesystem path
     impl = get_implementation(implementation, implementation_config)
     try:
         zarr_format = None
         if mode in ("w", "w-") or (is_fs and mode == "a" and not store_path.exists()):
-            zarr_format = 2 if version == "0.4" else 3
+            zarr_format = zarr_format_for_version(version)
         root = impl.open_group(store_path, mode=mode, zarr_format=zarr_format)
     except (FileNotFoundError, FileExistsError, PermissionError):
         raise
     except Exception as e:
         raise StoreOpenError(f"Cannot open Zarr root group at {store_path!r}") from e
     return root, impl
+
+
+def _open_ozx_store(
+    path: Path,
+    mode: Literal["r", "r+", "a", "w", "w-"],
+    version: Literal["0.4", "0.5"],
+    implementation: str | None,
+) -> tuple[OzxStore, Literal["0.4", "0.5"]]:
+    """Build an ``OzxStore`` for an ``.ozx`` path and resolve the NGFF version.
+
+    iohub's mode taxonomy (``{r, r+, a, w, w-}``) maps onto ZipStore's
+    narrower set (``{r, w, a}``). ``r+`` degrades to ``r`` because zip
+    entries are immutable — the first write would error anyway.
+    """
+    if implementation not in (None, "zarr"):
+        raise ValueError(f"Implementation {implementation!r} does not support RFC-9 .ozx archives; use 'zarr'.")
+    if mode == "r+":
+        _logger.warning("RFC-9 .ozx archives cannot be mutated in place; opening read-only instead.")
+
+    exists = path.exists()
+    if mode in ("w", "w-") or (mode == "a" and not exists):
+        zip_mode: Literal["r", "w", "a"] = "w"
+    elif mode == "a":
+        zip_mode = "a"
+    else:
+        zip_mode = "r"
+
+    # Trust the archive's advertised version over the caller's hint.
+    resolved: Literal["0.4", "0.5"] = version
+    if zip_mode != "w" and exists:
+        advertised = read_ozx_version(path)
+        if advertised in ("0.4", "0.5"):
+            resolved = advertised  # type: ignore[assignment]
+    return OzxStore(path, mode=zip_mode, ome_version=resolved), resolved
 
 
 def _scale_integers(values: tuple[int, ...], factor: int) -> tuple[int, ...]:
@@ -2910,11 +2951,12 @@ def _check_file_mode(
             raise FileExistsError(store_path)
     elif mode == "w":
         if is_fs and store_path.exists():
-            if ".zarr" not in str(store_path.resolve()) and not disable_path_checking:
+            resolved = str(store_path.resolve())
+            if ".zarr" not in resolved and not is_ozx_path(resolved) and not disable_path_checking:
                 raise ValueError(
-                    "Cannot overwrite a path that does not contain '.zarr', "
-                    "use `disable_path_checking=True` if you are sure that "
-                    f"{store_path} should be overwritten."
+                    "Cannot overwrite a path that does not contain '.zarr' "
+                    "or end with '.ozx', use `disable_path_checking=True` "
+                    f"if you are sure that {store_path} should be overwritten."
                 )
             _logger.warning(f"Overwriting data at {store_path}")
     else:

--- a/src/iohub/reader.py
+++ b/src/iohub/reader.py
@@ -101,8 +101,13 @@ def _get_sub_dirs(directory: Path) -> list[str]:
 
 
 def _infer_format(path: Path):
+    from iohub.core.ozx import is_ozx_path, read_ozx_version
+
     extra_info = None
-    if ngff_version := _check_zarr_data_type(path):
+    if is_ozx_path(path):
+        data_type = "omezarr"
+        extra_info = read_ozx_version(path) or "0.5"
+    elif ngff_version := _check_zarr_data_type(path):
         data_type = "omezarr"
         extra_info = ngff_version
     elif _check_ndtiff(path):

--- a/src/iohub/reader.py
+++ b/src/iohub/reader.py
@@ -8,6 +8,7 @@ import natsort
 import tifffile as tiff
 import zarr
 
+from iohub.core.ozx import is_ozx_path, read_ozx_version, summarize_ozx
 from iohub.fov import BaseFOVMapping
 from iohub.mmstack import MMStack
 from iohub.ndtiff import NDTiffDataset
@@ -101,8 +102,6 @@ def _get_sub_dirs(directory: Path) -> list[str]:
 
 
 def _infer_format(path: Path):
-    from iohub.core.ozx import is_ozx_path, read_ozx_version
-
     extra_info = None
     if is_ozx_path(path):
         data_type = "omezarr"
@@ -275,6 +274,8 @@ def print_info(path: StrOrBytesPath, verbose=False):
                         f">>> dataset = open_ome_zarr('{path}', mode='r')",
                     ]
                 )
+                if is_ozx_path(path):
+                    msgs.extend(_rfc9_info_lines(path))
             if isinstance(reader, Position):
                 print("Zarr hierarchy:")
                 reader.print_tree()
@@ -282,6 +283,18 @@ def print_info(path: StrOrBytesPath, verbose=False):
     finally:
         if hasattr(reader, "close"):
             reader.close()
+
+
+def _rfc9_info_lines(path: Path) -> list[str]:
+    """Return one-line summary entries for an ``.ozx`` archive's RFC-9 metadata."""
+    s = summarize_ozx(path)
+    return [
+        "\n=== RFC-9 archive ===",
+        f"OME version:\t\t {s.version}",
+        f"jsonFirst:\t\t {s.json_first}",
+        f"Entries:\t\t {s.n_entries:,}  ({s.n_zarr_json} zarr.json, {s.n_duplicates} duplicate names)",
+        f"Size on disk:\t\t {sizeof_fmt(path.stat().st_size)}",
+    ]
 
 
 def sizeof_fmt(num: int) -> str:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -140,6 +140,77 @@ def test_cli_convert_invalid_version(tmpdir):
     assert "Invalid value" in result.output
 
 
+def test_cli_info_verbose_ozx_shows_rfc9(tmpdir):
+    """``iohub info -v <ozx>`` shows the FOV summary plus the RFC-9 block."""
+    import numpy as np
+
+    from iohub.core.ozx import pack_ozx
+    from tests.conftest import make_fov_zarr
+
+    src = Path(tmpdir) / "src.zarr"
+    make_fov_zarr(src, np.zeros((1, 1, 1, 4, 4), dtype=np.uint8))
+    ozx = Path(tmpdir) / "src.ozx"
+    pack_ozx(src, ozx)
+
+    runner = CliRunner()
+    res = runner.invoke(cli, ["info", "-v", str(ozx)])
+    assert res.exit_code == 0, res.output
+    # FOV summary still present.
+    assert "Format:" in res.output
+    assert "Channel names:" in res.output
+    # RFC-9 block appended in verbose mode.
+    assert "=== RFC-9 archive ===" in res.output
+    assert "OME version:" in res.output
+    assert "jsonFirst:" in res.output
+
+
+def test_cli_info_non_verbose_ozx_skips_rfc9(tmpdir):
+    """Non-verbose ``info`` on a .ozx omits the RFC-9 block."""
+    import numpy as np
+
+    from iohub.core.ozx import pack_ozx
+    from tests.conftest import make_fov_zarr
+
+    src = Path(tmpdir) / "src.zarr"
+    make_fov_zarr(src, np.zeros((1, 1, 1, 2, 2), dtype=np.uint8))
+    ozx = Path(tmpdir) / "src.ozx"
+    pack_ozx(src, ozx)
+
+    runner = CliRunner()
+    res = runner.invoke(cli, ["info", str(ozx)])
+    assert res.exit_code == 0, res.output
+    assert "RFC-9 archive" not in res.output
+
+
+def test_cli_convert_zarr_to_ozx_and_back(tmpdir):
+    """`iohub convert` packs .zarr → .ozx and unpacks .ozx → .zarr based on suffix."""
+    import numpy as np
+
+    from tests.conftest import make_fov_zarr
+
+    src = Path(tmpdir) / "src.zarr"
+    data = np.arange(16, dtype=np.uint8).reshape(1, 1, 1, 4, 4)
+    make_fov_zarr(src, data)
+
+    runner = CliRunner()
+
+    ozx = Path(tmpdir) / "out.ozx"
+    res = runner.invoke(cli, ["convert", "-i", str(src), "-o", str(ozx)])
+    assert res.exit_code == 0, res.output
+    assert "packed" in res.output
+    assert ozx.is_file()
+
+    # Unpack: ozx → zarr
+    restored = Path(tmpdir) / "restored.zarr"
+    res = runner.invoke(cli, ["convert", "-i", str(ozx), "-o", str(restored)])
+    assert res.exit_code == 0, res.output
+    assert "unpacked" in res.output
+    assert restored.is_dir()
+
+    with open_ome_zarr(restored, mode="r") as pos:
+        np.testing.assert_array_equal(pos["0"][:], np.arange(16, dtype=np.uint8).reshape(1, 1, 1, 4, 4))
+
+
 def test_cli_set_scale(caplog):
     with _temp_copy(hcs_ref) as store_path:
         store_path = Path(store_path)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -211,6 +211,43 @@ def test_cli_convert_zarr_to_ozx_and_back(tmpdir):
         np.testing.assert_array_equal(pos["0"][:], np.arange(16, dtype=np.uint8).reshape(1, 1, 1, 4, 4))
 
 
+@pytest.mark.parametrize(
+    ("flag", "value", "route"),
+    [
+        ("--chunks", "XY", "pack"),
+        ("-g", None, "pack"),
+        ("--chunks", "XY", "unpack"),
+        ("-g", None, "unpack"),
+        ("--ome-zarr-version", "0.5", "unpack"),
+    ],
+)
+def test_cli_convert_rejects_irrelevant_flags(tmpdir, flag, value, route):
+    """TIFF-only flags on pack/unpack and version on unpack must error loudly."""
+    import numpy as np
+
+    from tests.conftest import make_fov_zarr
+
+    src_zarr = Path(tmpdir) / "src.zarr"
+    make_fov_zarr(src_zarr, np.zeros((1, 1, 1, 2, 2), dtype=np.uint8))
+    if route == "pack":
+        src, dst = src_zarr, Path(tmpdir) / "out.ozx"
+    else:
+        ozx = Path(tmpdir) / "src.ozx"
+        from iohub.core.ozx import pack_ozx as _pack
+
+        _pack(src_zarr, ozx)
+        src, dst = ozx, Path(tmpdir) / "out.zarr"
+
+    cmd = ["convert", "-i", str(src), "-o", str(dst), flag]
+    if value is not None:
+        cmd.append(value)
+
+    runner = CliRunner()
+    res = runner.invoke(cli, cmd)
+    assert res.exit_code != 0
+    assert "do not apply" in res.output or "apply only" in res.output
+
+
 def test_cli_set_scale(caplog):
     with _temp_copy(hcs_ref) as store_path:
         store_path = Path(store_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -235,3 +235,18 @@ def aqz_ome_zarr_05(tmpdir):
     del stream
 
     return store_path
+
+
+def make_fov_zarr(path: Path, data: np.ndarray, version: str = "0.5") -> None:
+    """Write ``data`` into a fresh FOV-layout OME-Zarr at ``path``.
+
+    Test helper shared by ``tests/ngff/test_ozx.py`` and the ozx-aware
+    CLI tests in ``tests/cli/test_cli.py`` — both repeat the same write
+    pattern when building tiny fixtures.
+    """
+    from iohub import open_ome_zarr
+
+    chunks = tuple(max(1, s // 2) for s in data.shape)
+    with open_ome_zarr(path, layout="fov", mode="w", channel_names=["c"], version=version) as pos:
+        arr = pos.create_zeros("0", shape=data.shape, dtype=data.dtype, chunks=chunks)
+        arr[:] = data

--- a/tests/ngff/test_ozx.py
+++ b/tests/ngff/test_ozx.py
@@ -1,0 +1,101 @@
+"""Tests for RFC-9 (Zipped OME-Zarr, ``.ozx``) support."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from iohub import open_ome_zarr
+from iohub.core.ozx import (
+    is_ozx_path,
+    pack_ozx,
+    read_ozx_json_first,
+    read_ozx_version,
+)
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [("foo.ozx", True), ("FOO.OZX", True), ("foo.zarr", False)],
+)
+def test_is_ozx_path(path: str, expected: bool) -> None:
+    assert is_ozx_path(path) is expected
+
+
+def test_fov_roundtrip_v0_5(tmp_path: Path) -> None:
+    """End-to-end v0.5 write/read + verify RFC-9 archive shape."""
+    path = tmp_path / "fov.ozx"
+    data = np.arange(16, dtype=np.uint16).reshape(1, 1, 1, 4, 4)
+    with open_ome_zarr(path, layout="fov", mode="w", channel_names=["DAPI"], version="0.5") as pos:
+        arr = pos.create_zeros("0", shape=data.shape, dtype=data.dtype, chunks=(1, 1, 1, 2, 2))
+        arr[:] = data
+    with open_ome_zarr(path, mode="r") as pos:
+        assert pos.channel_names == ["DAPI"]
+        np.testing.assert_array_equal(pos["0"][:], data)
+    # RFC-9: archive comment carries OME version, all entries ZIP_STORED.
+    with zipfile.ZipFile(path) as zf:
+        assert json.loads(zf.comment) == {"ome": {"version": "0.5"}}
+        assert {info.compress_type for info in zf.infolist()} == {zipfile.ZIP_STORED}
+
+
+def test_fov_roundtrip_v0_4(tmp_path: Path) -> None:
+    """v0.4 uses zarr_format=2 — separate code path from v0.5."""
+    path = tmp_path / "fov_v04.ozx"
+    with open_ome_zarr(path, layout="fov", mode="w", channel_names=["GFP"], version="0.4") as pos:
+        pos.create_zeros("0", shape=(1, 1, 1, 2, 2), dtype=np.uint8, chunks=(1, 1, 1, 2, 2))
+    assert read_ozx_version(path) == "0.4"
+    with open_ome_zarr(path, mode="r") as pos:
+        assert pos.metadata.multiscales[0].version == "0.4"
+
+
+def test_hcs_roundtrip(tmp_path: Path) -> None:
+    """Plate layout writes multiple nested groups — different enough from FOV to test."""
+    path = tmp_path / "plate.ozx"
+    with open_ome_zarr(path, layout="hcs", mode="w", channel_names=["DAPI"], version="0.5") as plate:
+        for well in (("A", "1"), ("A", "2")):
+            pos = plate.create_position(*well, "0")
+            pos.create_zeros("0", shape=(1, 1, 1, 2, 2), dtype=np.uint8, chunks=(1, 1, 1, 2, 2))
+    with open_ome_zarr(path, mode="r") as plate:
+        assert plate.channel_names == ["DAPI"]
+        assert next(iter(plate["A/1"].positions()))[0] == "0"
+
+
+def test_pack_ozx_from_directory(tmp_path: Path) -> None:
+    """pack_ozx walks a .zarr dir, sniffs version, emits ordered .ozx."""
+    src_dir = tmp_path / "src.zarr"
+    with open_ome_zarr(src_dir, layout="fov", mode="w", channel_names=["c"], version="0.5") as pos:
+        arr = pos.create_zeros("0", shape=(1, 1, 1, 4, 4), dtype=np.uint8, chunks=(1, 1, 1, 2, 2))
+        arr[:] = np.ones(arr.shape, dtype=np.uint8)
+
+    dst = tmp_path / "out.ozx"
+    pack_ozx(src_dir, dst)
+
+    # Version sniffed from the source's zarr.json, jsonFirst flipped on.
+    assert read_ozx_version(dst) == "0.5"
+    assert read_ozx_json_first(dst) is True
+
+    # Roundtrip via the public API.
+    with open_ome_zarr(dst, mode="r") as pos:
+        np.testing.assert_array_equal(pos["0"][:], np.ones((1, 1, 1, 4, 4), dtype=np.uint8))
+
+    # Refuse overwriting existing destination.
+    with pytest.raises(FileExistsError):
+        pack_ozx(src_dir, dst)
+
+
+def test_tensorstore_rejected_for_ozx(tmp_path: Path) -> None:
+    """TS cannot write .ozx (its zip kvstore is read-only). Fail loud, not late."""
+    pytest.importorskip("tensorstore")
+    with pytest.raises(ValueError, match="does not support RFC-9"):
+        open_ome_zarr(
+            tmp_path / "ts.ozx",
+            layout="fov",
+            mode="w",
+            channel_names=["c"],
+            version="0.5",
+            implementation="tensorstore",
+        )

--- a/tests/ngff/test_ozx.py
+++ b/tests/ngff/test_ozx.py
@@ -2,58 +2,56 @@
 
 from __future__ import annotations
 
-import json
+import multiprocessing as mp
+import sys
 import zipfile
 from pathlib import Path
+from typing import Literal
 
 import numpy as np
 import pytest
+import zarr
 
 from iohub import open_ome_zarr
 from iohub.core.ozx import (
+    OzxStore,
     is_ozx_path,
     pack_ozx,
-    read_ozx_json_first,
     read_ozx_version,
+    summarize_ozx,
+    unpack_ozx,
 )
+from tests.conftest import make_fov_zarr
 
 
 @pytest.mark.parametrize(
     ("path", "expected"),
-    [("foo.ozx", True), ("FOO.OZX", True), ("foo.zarr", False)],
+    [
+        ("foo.ozx", True),
+        ("FOO.OZX", False),  # case-sensitive, matches .zarr precedent
+        ("foo.zarr", False),
+    ],
 )
 def test_is_ozx_path(path: str, expected: bool) -> None:
     assert is_ozx_path(path) is expected
 
 
-def test_fov_roundtrip_v0_5(tmp_path: Path) -> None:
-    """End-to-end v0.5 write/read + verify RFC-9 archive shape."""
-    path = tmp_path / "fov.ozx"
-    data = np.arange(16, dtype=np.uint16).reshape(1, 1, 1, 4, 4)
-    with open_ome_zarr(path, layout="fov", mode="w", channel_names=["DAPI"], version="0.5") as pos:
-        arr = pos.create_zeros("0", shape=data.shape, dtype=data.dtype, chunks=(1, 1, 1, 2, 2))
-        arr[:] = data
+@pytest.mark.parametrize("version", ["0.4", "0.5"])
+def test_fov_roundtrip(tmp_path: Path, version: Literal["0.4", "0.5"]) -> None:
+    """E2E write/read for both NGFF versions + verify RFC-9 archive shape."""
+    path = tmp_path / f"fov_{version}.ozx"
+    data = np.arange(16, dtype=np.uint8).reshape(1, 1, 1, 4, 4)
+    make_fov_zarr(path, data, version=version)
+    assert read_ozx_version(path) == version
     with open_ome_zarr(path, mode="r") as pos:
-        assert pos.channel_names == ["DAPI"]
         np.testing.assert_array_equal(pos["0"][:], data)
-    # RFC-9: archive comment carries OME version, all entries ZIP_STORED.
     with zipfile.ZipFile(path) as zf:
-        assert json.loads(zf.comment) == {"ome": {"version": "0.5"}}
+        assert zf.comment == f'{{"ome":{{"version":"{version}"}}}}'.encode()
         assert {info.compress_type for info in zf.infolist()} == {zipfile.ZIP_STORED}
 
 
-def test_fov_roundtrip_v0_4(tmp_path: Path) -> None:
-    """v0.4 uses zarr_format=2 — separate code path from v0.5."""
-    path = tmp_path / "fov_v04.ozx"
-    with open_ome_zarr(path, layout="fov", mode="w", channel_names=["GFP"], version="0.4") as pos:
-        pos.create_zeros("0", shape=(1, 1, 1, 2, 2), dtype=np.uint8, chunks=(1, 1, 1, 2, 2))
-    assert read_ozx_version(path) == "0.4"
-    with open_ome_zarr(path, mode="r") as pos:
-        assert pos.metadata.multiscales[0].version == "0.4"
-
-
 def test_hcs_roundtrip(tmp_path: Path) -> None:
-    """Plate layout writes multiple nested groups — different enough from FOV to test."""
+    """Plate layout exercises a different write path (nested groups)."""
     path = tmp_path / "plate.ozx"
     with open_ome_zarr(path, layout="hcs", mode="w", channel_names=["DAPI"], version="0.5") as plate:
         for well in (("A", "1"), ("A", "2")):
@@ -64,31 +62,167 @@ def test_hcs_roundtrip(tmp_path: Path) -> None:
         assert next(iter(plate["A/1"].positions()))[0] == "0"
 
 
-def test_pack_ozx_from_directory(tmp_path: Path) -> None:
-    """pack_ozx walks a .zarr dir, sniffs version, emits ordered .ozx."""
-    src_dir = tmp_path / "src.zarr"
-    with open_ome_zarr(src_dir, layout="fov", mode="w", channel_names=["c"], version="0.5") as pos:
-        arr = pos.create_zeros("0", shape=(1, 1, 1, 4, 4), dtype=np.uint8, chunks=(1, 1, 1, 2, 2))
-        arr[:] = np.ones(arr.shape, dtype=np.uint8)
+def test_pack_unpack_roundtrip(tmp_path: Path) -> None:
+    """``pack_ozx`` then ``unpack_ozx`` round-trips data, version, and ordering;
+    pack refuses to overwrite an existing destination.
+    """
+    src = tmp_path / "src.zarr"
+    data = np.arange(64, dtype=np.uint8).reshape(1, 1, 1, 8, 8)
+    make_fov_zarr(src, data)
 
-    dst = tmp_path / "out.ozx"
-    pack_ozx(src_dir, dst)
+    ozx = tmp_path / "src.ozx"
+    pack_ozx(src, ozx)
+    s = summarize_ozx(ozx)
+    assert s.version == "0.5"  # sniffed from src
+    assert s.json_first is True  # BFS-ordered output
 
-    # Version sniffed from the source's zarr.json, jsonFirst flipped on.
-    assert read_ozx_version(dst) == "0.5"
-    assert read_ozx_json_first(dst) is True
+    restored = tmp_path / "restored.zarr"
+    unpack_ozx(ozx, restored)
+    with open_ome_zarr(restored, mode="r") as pos:
+        np.testing.assert_array_equal(pos["0"][:], data)
 
-    # Roundtrip via the public API.
-    with open_ome_zarr(dst, mode="r") as pos:
-        np.testing.assert_array_equal(pos["0"][:], np.ones((1, 1, 1, 4, 4), dtype=np.uint8))
-
-    # Refuse overwriting existing destination.
     with pytest.raises(FileExistsError):
-        pack_ozx(src_dir, dst)
+        pack_ozx(src, ozx)
+
+
+def test_unpack_ozx_dedupes_shadow_entries(tmp_path: Path) -> None:
+    """Duplicate entry names (shadow writes) collapse to the last — matches
+    ``ZipFile.read`` resolution."""
+    ozx = tmp_path / "shadow.ozx"
+    with zipfile.ZipFile(ozx, mode="w", compression=zipfile.ZIP_STORED, allowZip64=True) as zf:
+        zf.writestr("zarr.json", b'{"shadow": true}')
+        zf.writestr("zarr.json", b'{"shadow": false}')
+
+    out = tmp_path / "unpacked"
+    unpack_ozx(ozx, out)
+    assert (out / "zarr.json").read_text() == '{"shadow": false}'
+
+
+def test_unpack_ozx_rejects_path_traversal(tmp_path: Path) -> None:
+    """Entries with ``..`` must not write outside ``dst``; partial output is removed."""
+    ozx = tmp_path / "evil.ozx"
+    with zipfile.ZipFile(ozx, mode="w", compression=zipfile.ZIP_STORED) as zf:
+        zf.writestr("../escape.txt", b"pwn")
+
+    out = tmp_path / "out"
+    with pytest.raises(ValueError, match="escapes destination"):
+        unpack_ozx(ozx, out)
+    # Cleanup-on-failure invariant: no half-written tree left behind.
+    assert not out.exists()
+
+
+def test_pack_ozx_cleans_up_on_write_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """If ``_write_ozx_archive`` raises mid-write, the partial ``.ozx`` is removed.
+
+    Otherwise users hit ``FileExistsError`` on retry from leftover output.
+    """
+    src = tmp_path / "src.zarr"
+    make_fov_zarr(src, np.zeros((1, 1, 1, 4, 4), dtype=np.uint8))
+    dst = tmp_path / "out.ozx"
+
+    # Force a failure mid-copy by patching shutil.copyfileobj inside the
+    # ozx module — _write_ozx_archive's try/except + unlink runs.
+    from iohub.core import ozx as ozx_mod
+
+    def boom(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("simulated mid-copy failure")
+
+    monkeypatch.setattr(ozx_mod.shutil, "copyfileobj", boom)
+    with pytest.raises(RuntimeError, match="simulated mid-copy"):
+        pack_ozx(src, dst)
+    # Cleanup-on-failure invariant: partial output unlinked.
+    assert not dst.exists()
+
+
+def test_unpack_ozx_handles_directory_entries(tmp_path: Path) -> None:
+    """Zips from other tools (7z, info-zip) sometimes include directory entries
+    (``name/`` with empty content). ``unpack_ozx`` must not crash on them.
+    """
+    ozx = tmp_path / "with_dirs.ozx"
+    with zipfile.ZipFile(ozx, mode="w", compression=zipfile.ZIP_STORED) as zf:
+        zf.writestr("zarr.json", b"{}")
+        zf.writestr("inner/", b"")  # directory entry — 7z-style
+        zf.writestr("inner/zarr.json", b"{}")
+
+    out = tmp_path / "out"
+    unpack_ozx(ozx, out)
+    assert (out / "zarr.json").is_file()
+    assert (out / "inner" / "zarr.json").is_file()
+
+
+def _build_summarize_fixture(tmp_path: Path, kind: str) -> Path:
+    """Make a fixture archive for ``test_summarize_ozx_edges``."""
+    path = tmp_path / f"{kind}.zip"
+    if kind == "missing_comment":
+        with zipfile.ZipFile(path, mode="w", compression=zipfile.ZIP_STORED) as zf:
+            zf.writestr("zarr.json", b"{}")
+    elif kind == "malformed_comment":
+        with zipfile.ZipFile(path, mode="w", compression=zipfile.ZIP_STORED) as zf:
+            zf.writestr("zarr.json", b"{}")
+            zf.comment = b"not json at all"
+    elif kind == "corrupt_zip":
+        path.write_bytes(b"\x00" * 1024)
+    return path
+
+
+@pytest.mark.parametrize("kind", ["missing_comment", "malformed_comment", "corrupt_zip"])
+def test_summarize_ozx_edges(tmp_path: Path, kind: str) -> None:
+    """Summary degrades gracefully for missing/malformed comments and propagates
+    ``BadZipFile`` for corrupt archives — no silent ``n_entries=0``.
+    """
+    path = _build_summarize_fixture(tmp_path, kind)
+    if kind == "corrupt_zip":
+        with pytest.raises(zipfile.BadZipFile):
+            summarize_ozx(path)
+        return
+    s = summarize_ozx(path)
+    assert s.version is None
+    assert s.json_first is False
+    assert s.n_entries == 1
+
+
+def _read_many_in_child(ozx_path_str: str, n_iters: int, q: mp.Queue) -> None:
+    store = OzxStore(ozx_path_str, mode="r")
+    grp = zarr.open_group(store=store, mode="r")
+    arr = grp["0"]
+    digests = [bytes(arr[:].tobytes()) for _ in range(n_iters)]
+    store.close()
+    q.put(digests)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="fork only on POSIX")
+def test_fork_safety(tmp_path: Path) -> None:
+    """Fork-children reading from a parent-opened archive each get a clean fd."""
+    src = tmp_path / "src.zarr"
+    # 16 chunks total (4x4 grid); each child reads them all ``n_iters``
+    # times to maximize the chance a shared-fd race surfaces.
+    data = np.arange(256, dtype=np.uint8).reshape(1, 1, 1, 16, 16)
+    make_fov_zarr(src, data)
+    ozx_path = tmp_path / "src.ozx"
+    pack_ozx(src, ozx_path)
+
+    parent_store = OzxStore(ozx_path, mode="r")
+    parent_grp = zarr.open_group(store=parent_store, mode="r")
+    expected = parent_grp["0"][:].tobytes()
+
+    ctx = mp.get_context("fork")
+    q: mp.Queue = ctx.Queue()
+    n_workers, n_iters = 4, 5
+    procs = [ctx.Process(target=_read_many_in_child, args=(str(ozx_path), n_iters, q)) for _ in range(n_workers)]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=15)
+        assert p.exitcode == 0, f"child crashed: exitcode={p.exitcode}"
+
+    parent_store.close()
+    for _ in range(n_workers):
+        digests = q.get(timeout=2)
+        assert all(d == expected for d in digests)
 
 
 def test_tensorstore_rejected_for_ozx(tmp_path: Path) -> None:
-    """TS cannot write .ozx (its zip kvstore is read-only). Fail loud, not late."""
+    """TS cannot write ``.ozx`` (its zip kvstore is read-only). Fail loud, not late."""
     pytest.importorskip("tensorstore")
     with pytest.raises(ValueError, match="does not support RFC-9"):
         open_ome_zarr(

--- a/tests/ngff/test_ozx.py
+++ b/tests/ngff/test_ozx.py
@@ -1,7 +1,5 @@
 """Tests for RFC-9 (Zipped OME-Zarr, ``.ozx``) support."""
 
-from __future__ import annotations
-
 import multiprocessing as mp
 import sys
 import zipfile


### PR DESCRIPTION
Adds [RFC-9 Zipped OME-Zarr](https://ngff.openmicroscopy.org/rfc/9/) (`.ozx`) — a single-file archive for distribution.

```bash
iohub convert -i dataset.zarr -o dataset.ozx     # pack
iohub convert -i dataset.ozx  -o restored.zarr   # unpack
iohub info -v dataset.ozx                        # FOV summary + RFC-9 properties
```

`open_ome_zarr("dataset.ozx")` works in Python with no flags. Fork-safe via `os.register_at_fork`, so PyTorch `DataLoader(num_workers>0)` works on Linux.