### PR TITLE
feat(cli): add iohub compute-pyramid command

### DIFF
--- a/src/iohub/cli/cli.py
+++ b/src/iohub/cli/cli.py
@@ -209,12 +209,12 @@ def _parse_dims(ctx, param, value):
     required=False,
     default=None,
     callback=_parse_dims,
-    help=("Comma-separated axes to downsample (e.g. 'y,x' for YX-only). Defaults to 'z,y,x' inside iohub."),
+    help=("Comma-separated axes to downsample (e.g. 'y,x' for YX-only). Defaults to 'z,y,x'."),
 )
 def compute_pyramid(input_position_dirpaths, levels, method, dims):
     """Compute multiscale pyramid levels in place for OME-Zarr positions.
 
-    The level-0 array is preserved; new downsampled levels are appended.
+    The level 0 array is preserved; new downsampled levels are appended.
 
     ```
     iohub compute-pyramid -i input.zarr/*/*/* --levels 4

--- a/src/iohub/cli/cli.py
+++ b/src/iohub/cli/cli.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 
 import click
@@ -7,6 +8,8 @@ from iohub.cli.parsing import input_position_dirpaths
 from iohub.convert import TIFFConverter
 from iohub.reader import print_info
 from iohub.rename_wells import rename_wells
+
+_logger = logging.getLogger(__name__)
 
 VERSION = __version__
 
@@ -161,6 +164,65 @@ def set_scale(
                 if value is None:
                     continue
                 dataset.set_scale(image, name, value)
+
+
+_PYRAMID_METHODS = ["mean", "median", "mode", "min", "max", "stride"]
+_PYRAMID_DIM_CHOICES = ["t", "z", "y", "x"]
+
+
+def _parse_dims(ctx, param, value):
+    if value is None:
+        return None
+    tokens = [t.strip().lower() for t in value.split(",") if t.strip()]
+    if not tokens:
+        return None
+    invalid = [t for t in tokens if t not in _PYRAMID_DIM_CHOICES]
+    if invalid:
+        raise click.BadParameter(f"Unknown dim(s) {invalid}. Valid choices: {_PYRAMID_DIM_CHOICES}.")
+    return set(tokens)
+
+
+@cli.command(name="compute-pyramid")
+@click.help_option("-h", "--help")
+@input_position_dirpaths()
+@click.option(
+    "--levels",
+    "-l",
+    required=True,
+    type=click.IntRange(min=2),
+    help="Total number of pyramid levels including level 0 (e.g. 4 = level 0 + 3 extra).",
+)
+@click.option(
+    "--method",
+    "-m",
+    required=False,
+    default="mean",
+    show_default=True,
+    type=click.Choice(_PYRAMID_METHODS),
+    help="Downsampling method.",
+)
+@click.option(
+    "--dims",
+    "-d",
+    required=False,
+    default=None,
+    callback=_parse_dims,
+    help=("Comma-separated axes to downsample (e.g. 'y,x' for YX-only). Defaults to 'z,y,x' inside iohub."),
+)
+def compute_pyramid(input_position_dirpaths, levels, method, dims):
+    """Compute multiscale pyramid levels in place for OME-Zarr positions.
+
+    The level-0 array is preserved; new downsampled levels are appended.
+
+    ```
+    iohub compute-pyramid -i input.zarr/*/*/* --levels 4
+    iohub compute-pyramid -i input.zarr/*/*/* -l 3 -m median --dims y,x
+    ```
+    """
+    for input_position_dirpath in input_position_dirpaths:
+        _logger.info(f"Computing pyramid for {input_position_dirpath}")
+        with open_ome_zarr(input_position_dirpath, layout="fov", mode="r+") as dataset:
+            dataset.compute_pyramid(levels=levels, method=method, dims=dims)
 
 
 @cli.command(name="rename-wells")

--- a/src/iohub/cli/cli.py
+++ b/src/iohub/cli/cli.py
@@ -178,7 +178,9 @@ def _parse_dims(ctx, param, value):
         return None
     invalid = [t for t in tokens if t not in _PYRAMID_DIM_CHOICES]
     if invalid:
-        raise click.BadParameter(f"Unknown dim(s) {invalid}. Valid choices: {_PYRAMID_DIM_CHOICES}.")
+        invalid_dims = ", ".join(dict.fromkeys(invalid))
+        valid_dims = ", ".join(_PYRAMID_DIM_CHOICES)
+        raise click.BadParameter(f"Unknown dim(s): {invalid_dims}. Valid choices: {valid_dims}.")
     return set(tokens)
 
 

--- a/src/iohub/cli/cli.py
+++ b/src/iohub/cli/cli.py
@@ -166,8 +166,8 @@ def set_scale(
                 dataset.set_scale(image, name, value)
 
 
-_PYRAMID_METHODS = ["mean", "median", "mode", "min", "max", "stride"]
-_PYRAMID_DIM_CHOICES = ["t", "z", "y", "x"]
+_PYRAMID_METHODS = ("mean", "median", "mode", "min", "max", "stride")
+_PYRAMID_DIM_CHOICES = ("t", "z", "y", "x")
 
 
 def _parse_dims(ctx, param, value):
@@ -201,7 +201,7 @@ def _parse_dims(ctx, param, value):
     default="mean",
     show_default=True,
     type=click.Choice(_PYRAMID_METHODS),
-    help="Downsampling method.",
+    help="The Downsampling method.",
 )
 @click.option(
     "--dims",

--- a/src/iohub/ngff/utils.py
+++ b/src/iohub/ngff/utils.py
@@ -19,7 +19,6 @@ from iohub.core.compat import V04_MAX_CHUNK_SIZE_BYTES
 from iohub.ngff import open_ome_zarr
 from iohub.ngff.nodes import TransformationMeta
 
-
 #: Default ZYX chunk size for OME-Zarr v0.5 stores: ~2 MB at uint16 / ~4 MB at float32.
 _V05_DEFAULT_ZYX_CHUNKS: tuple[int, int, int] = (16, 256, 256)
 
@@ -430,10 +429,7 @@ def process_single_position(
     elif use_threads:
         click.echo(f"\nStarting thread pool with {num_workers} threads")
         with ThreadPoolExecutor(max_workers=num_workers) as p:
-            futures = [
-                p.submit(partial_apply_transform_to_czyx_and_save, *args)
-                for args in flat_iterable
-            ]
+            futures = [p.submit(partial_apply_transform_to_czyx_and_save, *args) for args in flat_iterable]
             for fut in as_completed(futures):
                 fut.result()
         click.echo("Shut down thread pool")
@@ -446,13 +442,8 @@ def process_single_position(
         # (e.g. cgroup OOM-kill) surfaces as BrokenProcessPool instead
         # of hanging indefinitely on pool.starmap.
         context = mp.get_context("spawn")
-        with ProcessPoolExecutor(
-            max_workers=num_workers, mp_context=context
-        ) as p:
-            futures = [
-                p.submit(partial_apply_transform_to_czyx_and_save, *args)
-                for args in flat_iterable
-            ]
+        with ProcessPoolExecutor(max_workers=num_workers, mp_context=context) as p:
+            futures = [p.submit(partial_apply_transform_to_czyx_and_save, *args) for args in flat_iterable]
             for fut in as_completed(futures):
                 fut.result()
         click.echo("Shut down multiprocess pool")

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -3,6 +3,7 @@ import re
 from pathlib import Path
 from unittest.mock import patch
 
+import numpy as np
 import pytest
 from click.testing import CliRunner
 
@@ -217,3 +218,127 @@ def test_cli_rename_wells(csv_data_file_1):
 
         assert result.exit_code == 0
         assert "Renaming" in result.output
+
+
+def _make_pyramid_test_plate(store_path: Path) -> tuple[tuple[int, ...], list[str]]:
+    """Create a tiny plate with a single position and a level-0 array.
+
+    Returns the level-0 shape and the position key (row, col, fov).
+    """
+    shape = (1, 2, 8, 64, 64)
+    rng = np.random.default_rng(0)
+    data = rng.integers(0, 255, size=shape, dtype=np.uint16)
+    position_key = ("A", "1", "0")
+    with open_ome_zarr(
+        store_path,
+        layout="hcs",
+        mode="w",
+        channel_names=["ch1", "ch2"],
+    ) as plate:
+        position = plate.create_position(*position_key)
+        position.create_image("0", data)
+    return shape, list(position_key)
+
+
+def test_cli_compute_pyramid(tmp_path, caplog):
+    store_path = tmp_path / "compute_pyramid.zarr"
+    shape, position_key = _make_pyramid_test_plate(store_path)
+    position_path = store_path.joinpath(*position_key)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "compute-pyramid",
+            "-i",
+            str(position_path),
+            "--levels",
+            "3",
+            "--method",
+            "mean",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert any("Computing pyramid" in record.message for record in caplog.records)
+
+    with open_ome_zarr(position_path, layout="fov", mode="r") as pos:
+        dataset_paths = pos.metadata.multiscales[0].get_dataset_paths()
+        assert dataset_paths == ["0", "1", "2"]
+        assert pos["0"].shape == shape
+        # Cascade YX/Z downsampling halves spatial axes per level.
+        assert pos["1"].shape[-2:] == (shape[-2] // 2, shape[-1] // 2)
+        assert pos["2"].shape[-2:] == (shape[-2] // 4, shape[-1] // 4)
+
+
+def test_cli_compute_pyramid_plate_glob(tmp_path):
+    store_path = tmp_path / "compute_pyramid_plate.zarr"
+    _, position_key = _make_pyramid_test_plate(store_path)
+    position_path = store_path.joinpath(*position_key)
+
+    runner = CliRunner()
+    # Pass the plate root: `_validate_and_process_paths` expands it into positions.
+    result = runner.invoke(
+        cli,
+        ["compute-pyramid", "-i", str(store_path), "-l", "2"],
+    )
+    assert result.exit_code == 0, result.output
+
+    with open_ome_zarr(position_path, layout="fov", mode="r") as pos:
+        dataset_paths = pos.metadata.multiscales[0].get_dataset_paths()
+        assert dataset_paths == ["0", "1"]
+
+
+def test_cli_compute_pyramid_dims(tmp_path):
+    store_path = tmp_path / "compute_pyramid_dims.zarr"
+    shape, position_key = _make_pyramid_test_plate(store_path)
+    position_path = store_path.joinpath(*position_key)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "compute-pyramid",
+            "-i",
+            str(position_path),
+            "-l",
+            "2",
+            "--dims",
+            "y,x",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    with open_ome_zarr(position_path, layout="fov", mode="r") as pos:
+        # Z is preserved; YX halved.
+        assert pos["1"].shape[-3] == shape[-3]
+        assert pos["1"].shape[-2:] == (shape[-2] // 2, shape[-1] // 2)
+
+
+def test_cli_compute_pyramid_help():
+    runner = CliRunner()
+    for option in ("-h", "--help"):
+        result = runner.invoke(cli, ["compute-pyramid", option])
+        assert result.exit_code == 0
+        assert "compute-pyramid" in result.output or "Compute multiscale" in result.output
+
+
+def test_cli_compute_pyramid_invalid_dims(tmp_path):
+    store_path = tmp_path / "compute_pyramid_bad_dims.zarr"
+    _, position_key = _make_pyramid_test_plate(store_path)
+    position_path = store_path.joinpath(*position_key)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "compute-pyramid",
+            "-i",
+            str(position_path),
+            "-l",
+            "2",
+            "--dims",
+            "y,bogus",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "bogus" in result.output

--- a/tests/ngff/test_ngff_utils.py
+++ b/tests/ngff/test_ngff_utils.py
@@ -14,10 +14,10 @@ from numpy.typing import DTypeLike
 from iohub.core.compat import V04_MAX_CHUNK_SIZE_BYTES
 from iohub.ngff import open_ome_zarr
 from iohub.ngff.utils import (
+    _V05_DEFAULT_ZYX_CHUNKS,
     _available_cpus,
     _indices_to_shard_aligned_batches,
     _match_indices_to_batches,
-    _V05_DEFAULT_ZYX_CHUNKS,
     apply_transform_to_tczyx_and_save,
     create_empty_plate,
     process_single_position,


### PR DESCRIPTION
## Summary

- Adds `iohub compute-pyramid` to the CLI, wrapping `Position.compute_pyramid` so users can build multiscale pyramid levels in place on existing OME-Zarr stores from the shell.
- Modeled on `iohub set-scale`: uses `@input_position_dirpaths()` (so plates and globs like `input.zarr/*/*/*` Just Work), opens each position with `mode=\"r+\"`, mutates in place.
- No new dependencies. Logger-based progress messages.

## Why

`Position.compute_pyramid` is already a public, tested method, but there is no shell-level entry point. Pipelines that produce a single-level zarr (e.g. `biahub concatenate`) currently need a custom Python script per project to add downsampled levels. Surfacing it as a CLI subcommand makes it a one-liner and matches the precedent set by `set-scale`.

## Usage

```sh
# Build 4 total levels (level 0 + 3 extra), default mean downsampling
iohub compute-pyramid -i input.zarr/*/*/* --levels 4

# Median, YX-only (preserve Z)
iohub compute-pyramid -i input.zarr/*/*/* -l 3 -m median --dims y,x

# Pass the plate root — gets expanded into positions automatically
iohub compute-pyramid -i input.zarr -l 4
```

## Options

| Option | | |
|---|---|---|
| \`-i / --input-position-dirpaths\` | required | Position glob (or plate root) |
| \`-l / --levels\` | required, int>=2 | Total levels including level 0 |
| \`-m / --method\` | default \`mean\` | One of mean/median/mode/min/max/stride |
| \`-d / --dims\` | optional | Comma list of axes to downsample, e.g. \`y,x\`. Defaults to z,y,x in iohub. |

## Tests

\`tests/cli/test_cli.py\` adds 5 new tests covering:

- Happy path with explicit \`--levels\` and \`--method\`, asserting cascade halving on YX
- Passing the plate root (verifies \`_validate_and_process_paths\` plate expansion)
- \`--dims y,x\` (Z preserved)
- \`--help\`
- Invalid \`--dims\` value rejected with non-zero exit

```
$ uv run pytest tests/cli/
74 passed in 10.26s
```

\`uvx prek run --files src/iohub/cli/cli.py tests/cli/test_cli.py\` is clean.

## Test plan

- [x] New CLI tests pass locally
- [x] Existing CLI suite still passes (\`tests/cli/\` 74/74)
- [x] \`uvx prek run\` clean (ruff check + ruff format + whitespace + EOF)
- [ ] CI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)