### PR TITLE
feat: add zarr-python as an optional zarr implementation (default is zarrs-python)

### DIFF
--- a/docs/examples/torch_dataloader.md
+++ b/docs/examples/torch_dataloader.md
@@ -1,10 +1,10 @@
 # Reading OME-Zarr in a PyTorch DataLoader
 
-iohub auto-selects the [zarrs](https://github.com/zarrs/zarrs-python) (Rust)
-codec pipeline whenever the `zarrs` package is installed. It is fast, but its
-parallel codec runs on a process-global thread pool that is **not fork-safe**.
-PyTorch's `DataLoader` forks worker processes on Linux when `num_workers > 0`,
-and the first chunk decode inside a forked worker deadlocks.
+iohub defaults to the `zarrs-python` implementation, which uses the
+[zarrs](https://github.com/zarrs/zarrs-python) (Rust) codec pipeline. It is
+fast, but its parallel codec runs on a process-global thread pool that is
+**not fork-safe**. PyTorch's `DataLoader` forks worker processes on Linux when
+`num_workers > 0`, and the first chunk decode inside a forked worker deadlocks.
 
 ## A tiny dataset
 
@@ -88,6 +88,16 @@ The simplest fix is to read in the main process, with no workers and no `fork()`
 
     Spawn re-imports your modules and pickles the `Dataset` for each worker,
     so startup is slower and throughput drops by roughly 10-20%.
+
+!!! tip "Or opt out of the Rust pipeline"
+
+    Pass `implementation="zarr-python"` to `open_ome_zarr` to use the pure-Python
+    codec pipeline, which is fork-safe and works with forked `DataLoader`
+    workers at the cost of slower decoding:
+
+    ```python title="dataset.py"
+    open_ome_zarr(store_path, mode="r", implementation="zarr-python")
+    ```
 
 !!! note "Why this happens"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,8 @@ tensorstore = [
 ]
 
 [project.entry-points."iohub.zarr_implementations"]
-zarr = "iohub.core.implementations.zarr_python:ZarrPythonImplementation"
+zarr-python = "iohub.core.implementations.zarr_python:ZarrPythonImplementation"
+zarrs-python = "iohub.core.implementations.zarr_python:ZarrsPythonImplementation"
 tensorstore = "iohub.core.implementations.tensorstore:TensorStoreImplementation"
 
 [dependency-groups]

--- a/src/iohub/core/config.py
+++ b/src/iohub/core/config.py
@@ -15,20 +15,21 @@ class CompressorConfig(BaseModel):
     shuffle: str = "bitshuffle"
 
 
-def _default_codec_pipeline() -> str:
-    """Use zarrs (Rust) codec pipeline if available, else default Python."""
-    try:
-        import zarrs  # noqa: F401
-
-        return "zarrs.ZarrsCodecPipeline"
-    except ImportError:
-        return "zarr.core.codec_pipeline.BatchedCodecPipeline"
+# Dotted paths to the codec pipelines selectable via the implementation name.
+PYTHON_CODEC_PIPELINE = "zarr.core.codec_pipeline.BatchedCodecPipeline"
+ZARRS_CODEC_PIPELINE = "zarrs.ZarrsCodecPipeline"
 
 
 class ZarrConfig(BaseModel):
-    """Config for the zarr-python implementation."""
+    """Config for the zarr-python implementation.
 
-    codec_pipeline: str = Field(default_factory=_default_codec_pipeline)
+    The codec pipeline defaults to the pure-Python pipeline. The selected
+    implementation name (``zarr-python`` vs ``zarrs-python``) determines which
+    pipeline is used when no explicit ``codec_pipeline`` is given; an explicit
+    value here always takes precedence.
+    """
+
+    codec_pipeline: str = PYTHON_CODEC_PIPELINE
     validate_checksums: bool = True
     compressor: CompressorConfig = Field(default_factory=CompressorConfig)
 

--- a/src/iohub/core/implementations/zarr_python.py
+++ b/src/iohub/core/implementations/zarr_python.py
@@ -7,7 +7,7 @@ from typing import Any
 import numpy as np
 import zarr
 
-from iohub.core.config import ZarrConfig
+from iohub.core.config import PYTHON_CODEC_PIPELINE, ZARRS_CODEC_PIPELINE, ZarrConfig
 from iohub.core.downsample import downsample_block, iter_work_regions, target_region_to_source
 from iohub.core.protocol import ZarrImplementation
 from iohub.core.specs import ArraySpec
@@ -15,10 +15,13 @@ from iohub.core.types import StorePath
 
 
 class ZarrPythonImplementation(ZarrImplementation[zarr.Group, zarr.Array]):
-    """Zarr-python backed I/O implementation."""
+    """Zarr-python backed I/O using the pure-Python codec pipeline."""
+
+    #: Default codec pipeline when no explicit ``ZarrConfig`` is provided.
+    _DEFAULT_CODEC_PIPELINE: str = PYTHON_CODEC_PIPELINE
 
     def __init__(self, config: ZarrConfig | None = None):
-        self.config = config or ZarrConfig()
+        self.config = config or ZarrConfig(codec_pipeline=self._DEFAULT_CODEC_PIPELINE)
         # Apply codec pipeline config globally — zarr-python reads this at I/O time,
         # not at group-open time, so it must persist beyond the open_group call.
         zarr.config.set(
@@ -180,3 +183,9 @@ class ZarrPythonImplementation(ZarrImplementation[zarr.Group, zarr.Array]):
         """Return shard/chunk-aligned regions for parallel iteration."""
         step_shape = self.get_shards(target) or target.chunks
         return iter_work_regions(target.shape, step_shape)
+
+
+class ZarrsPythonImplementation(ZarrPythonImplementation):
+    """Zarr-python backed I/O using the zarrs (Rust) codec pipeline."""
+
+    _DEFAULT_CODEC_PIPELINE: str = ZARRS_CODEC_PIPELINE

--- a/src/iohub/core/registry.py
+++ b/src/iohub/core/registry.py
@@ -11,14 +11,15 @@ from iohub.core.config import ImplementationConfig
 from iohub.core.errors import ImplementationNotFoundError
 
 _logger = logging.getLogger(__name__)
-_default: str = "zarr"
+_default: str = "zarrs-python"
 _IMPLEMENTATIONS: dict[str, type] = {}
 _discovered: bool = False
 _lock = threading.RLock()
 
-# Built-in implementations (always available, loaded before entrypoints)
+# Built-in implementations (always available, loaded before entrypoints).
 _BUILTINS: dict[str, str] = {
-    "zarr": "iohub.core.implementations.zarr_python:ZarrPythonImplementation",
+    "zarr-python": "iohub.core.implementations.zarr_python:ZarrPythonImplementation",
+    "zarrs-python": "iohub.core.implementations.zarr_python:ZarrsPythonImplementation",
 }
 
 
@@ -87,4 +88,4 @@ def _reset() -> None:
     global _discovered, _default
     _IMPLEMENTATIONS.clear()
     _discovered = False
-    _default = "zarr"
+    _default = "zarrs-python"

--- a/src/iohub/ngff/nodes.py
+++ b/src/iohub/ngff/nodes.py
@@ -123,8 +123,11 @@ def _open_ozx_store(
     narrower set (``{r, w, a}``). ``r+`` degrades to ``r`` because zip
     entries are immutable — the first write would error anyway.
     """
-    if implementation not in (None, "zarr"):
-        raise ValueError(f"Implementation {implementation!r} does not support RFC-9 .ozx archives; use 'zarr'.")
+    if implementation not in (None, "zarr-python", "zarrs-python"):
+        raise ValueError(
+            f"Implementation {implementation!r} does not support RFC-9 .ozx archives; "
+            "use 'zarr-python' or 'zarrs-python'."
+        )
     if mode == "r+":
         _logger.warning("RFC-9 .ozx archives cannot be mutated in place; opening read-only instead.")
 
@@ -3248,8 +3251,11 @@ def open_ome_zarr(
             if the input path is not checked carefully.
 
     implementation : str, optional
-        Name of the zarr implementation to use (e.g. "zarr", "tensorstore"),
-        by default None (uses the default implementation)
+        Name of the zarr implementation to use
+        (e.g. "zarrs-python", "zarr-python", "tensorstore"),
+        by default None (uses the default implementation, "zarrs-python").
+        "zarrs-python" uses the zarrs (Rust) codec pipeline;
+        "zarr-python" uses the pure-Python codec pipeline.
     implementation_config : ImplementationConfig, optional
         Configuration for the chosen implementation
         (e.g. ``ZarrConfig``, ``TensorStoreConfig``),

--- a/tests/core/test_registry.py
+++ b/tests/core/test_registry.py
@@ -42,7 +42,7 @@ def test_discover_zero_plugins_loads_builtins():
     """Builtins must be loaded even when no entrypoint plugins are installed."""
     with patch("iohub.core.registry.entry_points", return_value=[]):
         impls = available_implementations()
-    assert "zarr" in impls
+    assert "zarrs-python" in impls
 
 
 def test_discover_idempotent():
@@ -64,9 +64,9 @@ def test_discover_failed_builtin_logs_and_defers_error(caplog):
                 available_implementations()
 
     assert _reg._discovered is True
-    assert "zarr" not in _reg._IMPLEMENTATIONS
+    assert "zarrs-python" not in _reg._IMPLEMENTATIONS
     with pytest.raises(ImplementationNotFoundError):
-        get_implementation("zarr")
+        get_implementation("zarrs-python")
 
 
 # ---------------------------------------------------------------------------
@@ -75,18 +75,18 @@ def test_discover_failed_builtin_logs_and_defers_error(caplog):
 
 
 def test_reset_roundtrip():
-    """After _reset(), get_implementation() re-discovers and returns the zarr impl."""
-    get_implementation("zarr")  # populate
+    """After _reset(), get_implementation() re-discovers and returns the impl."""
+    get_implementation("zarrs-python")  # populate
     _reset()
-    impl = get_implementation("zarr")
+    impl = get_implementation("zarrs-python")
     assert impl is not None
 
 
 def test_reset_clears_default():
-    """_reset() restores _default to 'zarr'."""
-    set_default_implementation("zarr")
+    """_reset() restores _default to 'zarrs-python'."""
+    set_default_implementation("zarr-python")
     _reset()
-    assert _reg._default == "zarr"
+    assert _reg._default == "zarrs-python"
 
 
 # ---------------------------------------------------------------------------
@@ -95,23 +95,58 @@ def test_reset_clears_default():
 
 
 def test_get_implementation_zarr_returns_instance():
-    impl = get_implementation("zarr")
+    impl = get_implementation("zarr-python")
     from iohub.core.implementations.zarr_python import ZarrPythonImplementation
 
     assert isinstance(impl, ZarrPythonImplementation)
 
 
 def test_get_implementation_unknown_raises():
-    get_implementation("zarr")  # ensure discovered
+    get_implementation("zarr-python")  # ensure discovered
     with pytest.raises(ImplementationNotFoundError, match="nonexistent"):
         get_implementation("nonexistent")
 
 
-def test_get_implementation_default_is_zarr():
+def test_get_implementation_default_is_zarrs_python():
+    """The default implementation is zarrs-python (zarrs codec pipeline)."""
     impl = get_implementation()
-    from iohub.core.implementations.zarr_python import ZarrPythonImplementation
+    from iohub.core.config import ZARRS_CODEC_PIPELINE
+    from iohub.core.implementations.zarr_python import ZarrsPythonImplementation
 
-    assert isinstance(impl, ZarrPythonImplementation)
+    assert isinstance(impl, ZarrsPythonImplementation)
+    assert impl.config.codec_pipeline == ZARRS_CODEC_PIPELINE
+
+
+# ---------------------------------------------------------------------------
+# zarr-python vs zarrs-python implementation names
+# ---------------------------------------------------------------------------
+
+
+def test_available_implementations_includes_new_names():
+    impls = available_implementations()
+    assert {"zarr-python", "zarrs-python"} <= set(impls)
+
+
+def test_zarr_python_uses_python_codec_pipeline():
+    from iohub.core.config import PYTHON_CODEC_PIPELINE
+
+    impl = get_implementation("zarr-python")
+    assert impl.config.codec_pipeline == PYTHON_CODEC_PIPELINE
+
+
+def test_zarrs_python_uses_zarrs_codec_pipeline():
+    from iohub.core.config import ZARRS_CODEC_PIPELINE
+
+    impl = get_implementation("zarrs-python")
+    assert impl.config.codec_pipeline == ZARRS_CODEC_PIPELINE
+
+
+def test_explicit_config_overrides_implementation_default():
+    """An explicit ZarrConfig.codec_pipeline wins over the impl's default."""
+    from iohub.core.config import PYTHON_CODEC_PIPELINE, ZarrConfig
+
+    impl = get_implementation("zarrs-python", config=ZarrConfig(codec_pipeline=PYTHON_CODEC_PIPELINE))
+    assert impl.config.codec_pipeline == PYTHON_CODEC_PIPELINE
 
 
 # ---------------------------------------------------------------------------
@@ -120,13 +155,13 @@ def test_get_implementation_default_is_zarr():
 
 
 def test_set_default_implementation_happy():
-    register_implementation("custom", type(get_implementation("zarr")))
+    register_implementation("custom", type(get_implementation("zarrs-python")))
     set_default_implementation("custom")
     assert _reg._default == "custom"
 
 
 def test_set_default_implementation_unknown_raises():
-    get_implementation("zarr")  # ensure discovered
+    get_implementation("zarrs-python")  # ensure discovered
     with pytest.raises(ImplementationNotFoundError, match="nonexistent"):
         set_default_implementation("nonexistent")
 
@@ -136,5 +171,5 @@ def test_set_default_implementation_unknown_raises():
 # ---------------------------------------------------------------------------
 
 
-def test_available_implementations_includes_zarr():
-    assert "zarr" in available_implementations()
+def test_available_implementations_includes_zarr_python():
+    assert "zarr-python" in available_implementations()

--- a/tests/ngff/test_ngff.py
+++ b/tests/ngff/test_ngff.py
@@ -684,7 +684,7 @@ def test_write_more_channels(channels_and_random_5d, arr_name, version):
             pass
 
 
-@pytest.mark.parametrize("implementation", ["zarr", "tensorstore"])
+@pytest.mark.parametrize("implementation", ["zarr-python", "zarrs-python", "tensorstore"])
 @given(
     ch_shape_dtype=_channels_and_random_5d_shape_and_dtype(),
     arr_name=short_alpha_numeric,
@@ -944,7 +944,7 @@ def test_create_tiled(channel_names, version):
     grid_shape=tiles_rc_st,
     arr_name=short_alpha_numeric,
 )
-@pytest.mark.parametrize("implementation", ["zarr", "tensorstore"])
+@pytest.mark.parametrize("implementation", ["zarrs-python", "tensorstore"])
 @settings(suppress_health_check=[HealthCheck.too_slow])
 def test_make_tiles(implementation, channels_and_random_5d, grid_shape, arr_name):
     if implementation == "tensorstore":
@@ -980,7 +980,7 @@ def test_make_tiles(implementation, channels_and_random_5d, grid_shape, arr_name
                     tiles.get_tile(*args)
 
 
-@pytest.mark.parametrize("implementation", ["zarr", "tensorstore"])
+@pytest.mark.parametrize("implementation", ["zarrs-python", "tensorstore"])
 @given(
     channels_and_random_5d=_channels_and_random_5d(),
     grid_shape=tiles_rc_st,
@@ -1034,7 +1034,7 @@ def test_write_read_tiles(implementation, channels_and_random_5d, grid_shape, ar
                 assert_allclose(data, read)
 
 
-@pytest.mark.parametrize("implementation", ["zarr", "tensorstore"])
+@pytest.mark.parametrize("implementation", ["zarrs-python", "tensorstore"])
 @given(channel_names=channel_names_st)
 @settings(max_examples=16)
 def test_create_hcs(implementation, channel_names):
@@ -1050,7 +1050,7 @@ def test_create_hcs(implementation, channel_names):
         assert dataset.channel_names == channel_names
 
 
-@pytest.mark.parametrize("implementation", ["zarr", "tensorstore"])
+@pytest.mark.parametrize("implementation", ["zarrs-python", "tensorstore"])
 @pytest.mark.parametrize("version", ["0.5"])
 def test_open_hcs_create_empty(implementation, version):
     if implementation == "tensorstore":
@@ -1698,7 +1698,7 @@ def test_initialize_pyramid(tmp_path):
             ]
 
 
-@pytest.mark.parametrize("implementation", ["zarr", "tensorstore"])
+@pytest.mark.parametrize("implementation", ["zarrs-python", "tensorstore"])
 def test_compute_pyramid(tmp_path, implementation):
     """Test pyramid computation fills levels with downsampled data."""
     if implementation == "tensorstore":
@@ -1732,7 +1732,7 @@ def test_compute_pyramid(tmp_path, implementation):
             pos.compute_pyramid(levels=2, method="mean")
 
 
-@pytest.mark.parametrize("implementation", ["zarr", "tensorstore"])
+@pytest.mark.parametrize("implementation", ["zarrs-python", "tensorstore"])
 def test_delete_pyramid(tmp_path, implementation):
     """Test delete_pyramid removes all pyramid levels except level 0."""
     if implementation == "tensorstore":
@@ -1784,7 +1784,7 @@ def test_delete_pyramid(tmp_path, implementation):
 
 
 @given(config=_pyramid_config())
-@pytest.mark.parametrize("implementation", ["zarr", "tensorstore"])
+@pytest.mark.parametrize("implementation", ["zarrs-python", "tensorstore"])
 @settings(max_examples=32)
 def test_initialize_pyramid_shapes(implementation, config):
     if implementation == "tensorstore":
@@ -1823,7 +1823,7 @@ def test_initialize_pyramid_shapes(implementation, config):
                 prev_shape = current_shape
 
 
-@pytest.mark.parametrize("implementation", ["zarr", "tensorstore"])
+@pytest.mark.parametrize("implementation", ["zarrs-python", "tensorstore"])
 @given(config=_pyramid_config())
 @settings(max_examples=32)
 def test_initialize_pyramid_scale_metadata(implementation, config):
@@ -1859,7 +1859,7 @@ def test_initialize_pyramid_scale_metadata(implementation, config):
 
 
 @given(config=_pyramid_config())
-@pytest.mark.parametrize("implementation", ["zarr", "tensorstore"])
+@pytest.mark.parametrize("implementation", ["zarrs-python", "tensorstore"])
 @settings(max_examples=16, deadline=None, suppress_health_check=[HealthCheck.too_slow])
 def test_compute_pyramid_shapes(implementation, config):
     """Test compute_pyramid fills correct shapes for any dims subset."""
@@ -1890,7 +1890,7 @@ def test_compute_pyramid_shapes(implementation, config):
                 prev_shape = current_shape
 
 
-@pytest.mark.parametrize("implementation", ["zarr", "tensorstore"])
+@pytest.mark.parametrize("implementation", ["zarrs-python", "tensorstore"])
 def test_initialize_pyramid_invalid_dims(implementation, tmp_path):
     """Test that unknown axis names in dims raise ValueError."""
     if implementation == "tensorstore":

--- a/tests/ngff/test_ozx.py
+++ b/tests/ngff/test_ozx.py
@@ -231,3 +231,21 @@ def test_tensorstore_rejected_for_ozx(tmp_path: Path) -> None:
             version="0.5",
             implementation="tensorstore",
         )
+
+
+@pytest.mark.parametrize("implementation", ["zarr-python", "zarrs-python"])
+def test_zarr_python_implementations_roundtrip_ozx(tmp_path: Path, implementation: str) -> None:
+    """Both zarr-python codec pipelines write and read ``.ozx`` archives."""
+    path = tmp_path / f"{implementation}.ozx"
+    data = np.arange(16, dtype=np.uint8).reshape(1, 1, 1, 4, 4)
+    with open_ome_zarr(
+        path,
+        layout="fov",
+        mode="w",
+        channel_names=["c"],
+        version="0.5",
+        implementation=implementation,
+    ) as pos:
+        pos.create_image("0", data)
+    with open_ome_zarr(path, mode="r", implementation=implementation) as pos:
+        np.testing.assert_array_equal(pos["0"][:], data)

--- a/tests/ngff/test_xarray.py
+++ b/tests/ngff/test_xarray.py
@@ -488,7 +488,7 @@ class TestWriteXarray:
 # ── TensorStore backend tests ─────────────────────────────────────────────────
 
 
-@pytest.mark.parametrize("implementation", ["zarr", "tensorstore"])
+@pytest.mark.parametrize("implementation", ["zarrs-python", "tensorstore"])
 def test_to_xarray_tensorstore(implementation, tmp_path):
     """to_xarray() works with both zarr-python and tensorstore backends."""
     pytest.importorskip("tensorstore") if implementation == "tensorstore" else None
@@ -520,7 +520,7 @@ def test_to_xarray_tensorstore(implementation, tmp_path):
     assert_allclose(xa.coords["y"].values, np.arange(16) * 0.25)
 
 
-@pytest.mark.parametrize("implementation", ["zarr", "tensorstore"])
+@pytest.mark.parametrize("implementation", ["zarrs-python", "tensorstore"])
 def test_write_xarray_tensorstore(implementation, tmp_path):
     """write_xarray() roundtrip works with both zarr-python and tensorstore backends."""
     pytest.importorskip("tensorstore") if implementation == "tensorstore" else None

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -408,7 +408,7 @@ class TestVersionParameter:
         with pytest.raises(ValueError, match="Unsupported OME-NGFF version"):
             TIFFConverter(example_ome_tiff, output, version="0.3")
 
-    @pytest.mark.parametrize("impl", ["zarr", "tensorstore"])
+    @pytest.mark.parametrize("impl", ["zarrs-python", "tensorstore"])
     @pytest.mark.parametrize("ver", ["0.5"])
     def test_convert_writes_correct_version_and_preserves_data(self, example_ome_tiff, tmpdir, ver, impl):
         """Conversion write+read roundtrip preserves data for both backends."""


### PR DESCRIPTION
Lets users pick the Zarr codec pipeline in `open_ome_zarr`:

- `implementation="zarrs-python"`: `zarrs`,  Rust pipeline, default
- `implementation="zarr-python"`:  `zarr-python`, pure-Python pipeline, opt-in

The choice was previously implicit (`zarrs` auto-selected when installed); it's now explicit by name. Default behavior is unchanged.

Slight Breaking change

`implementation="zarr"` is removed, use `"zarrs-python"` or `"zarr-python"` or `"tensorstore"`.
