### PR TITLE
fix: merge extra_metadata in process_single_position instead of overwriting

### DIFF
--- a/src/iohub/ngff/utils.py
+++ b/src/iohub/ngff/utils.py
@@ -408,6 +408,11 @@ def process_single_position(
         can be passed to be stored at a FOV level,
         e.g.,
         kwargs={"extra_metadata": {"Temperature": 37.5, "CO2_level": 0.5}}.
+        When ``extra_metadata`` is a dict it is **merged** into any
+        existing ``extra_metadata`` on the output position (so metadata
+        written by ``create_empty_plate``'s ``metadata_sources`` is
+        preserved).  When ``extra_metadata`` is not provided, existing
+        metadata is left untouched.
     """
     click.echo(f"Function to be applied: \t{func}")
     click.echo(f"Input data path:\t{input_position_path}")
@@ -453,10 +458,21 @@ def process_single_position(
             a time index beyond the maximum index of
             the dataset = {time_ubound}""")
 
-    # Write extra metadata to the output store
+    # Merge extra metadata into the output store.  When extra_metadata is
+    # None the existing value (e.g. copied by create_empty_plate's
+    # metadata_sources) is preserved.  When a dict is given it is merged
+    # into any existing dict so that upstream keys are not lost.
     extra_metadata = kwargs.pop("extra_metadata", None)
-    with open_ome_zarr(output_position_path, layout="fov", mode="r+") as output_dataset:
-        output_dataset.zattrs["extra_metadata"] = extra_metadata
+    if extra_metadata is not None:
+        with open_ome_zarr(
+            output_position_path, layout="fov", mode="r+"
+        ) as output_dataset:
+            existing = output_dataset.zattrs.get("extra_metadata")
+            if isinstance(existing, dict):
+                existing.update(extra_metadata)
+                output_dataset.zattrs["extra_metadata"] = existing
+            else:
+                output_dataset.zattrs["extra_metadata"] = extra_metadata
 
     # Loop through (T, C), applying transform and writing as we go
     iterable = itertools.product(

--- a/tests/ngff/test_ngff_utils.py
+++ b/tests/ngff/test_ngff_utils.py
@@ -1095,6 +1095,85 @@ def test_process_single_position(setup, constant, num_workers, use_threads):
                 )
 
 
+def test_process_single_position_preserves_existing_extra_metadata():
+    """extra_metadata from metadata_sources is not clobbered when omitted."""
+    position_keys = [("A", "1", "0")]
+    channel_names = ["DAPI"]
+    shape = (1, 1, 1, 4, 4)
+    pre_existing = {"deskew": {"angle": 30.0}}
+
+    with _temp_ome_zarr_stores(
+        position_keys=position_keys,
+        channel_names=channel_names,
+        shape=shape,
+    ) as (input_store_path, output_store_path):
+        populate_store(input_store_path, position_keys, shape, np.float32)
+
+        # Simulate metadata_sources: write extra_metadata before processing
+        with open_ome_zarr(
+            output_store_path / "A/1/0", layout="fov", mode="r+"
+        ) as pos:
+            pos.zattrs["extra_metadata"] = pre_existing
+
+        # Call without extra_metadata kwarg — should NOT clobber
+        process_single_position(
+            func=dummy_transform,
+            input_position_path=input_store_path / Path("A", "1", "0"),
+            output_position_path=output_store_path / Path("A", "1", "0"),
+            input_channel_indices=[[0]],
+            output_channel_indices=[[0]],
+            input_time_indices=[0],
+            output_time_indices=[0],
+            constant=2,
+        )
+
+        with open_ome_zarr(
+            output_store_path / "A/1/0", layout="fov", mode="r"
+        ) as pos:
+            assert pos.zattrs["extra_metadata"] == pre_existing
+
+
+def test_process_single_position_merges_extra_metadata():
+    """extra_metadata kwarg merges with pre-existing metadata."""
+    position_keys = [("A", "1", "0")]
+    channel_names = ["DAPI"]
+    shape = (1, 1, 1, 4, 4)
+    pre_existing = {"deskew": {"angle": 30.0}}
+    new_metadata = {"flat_field": {"method": "basic"}}
+
+    with _temp_ome_zarr_stores(
+        position_keys=position_keys,
+        channel_names=channel_names,
+        shape=shape,
+    ) as (input_store_path, output_store_path):
+        populate_store(input_store_path, position_keys, shape, np.float32)
+
+        # Simulate metadata_sources: write extra_metadata before processing
+        with open_ome_zarr(
+            output_store_path / "A/1/0", layout="fov", mode="r+"
+        ) as pos:
+            pos.zattrs["extra_metadata"] = pre_existing
+
+        # Call WITH extra_metadata — should merge, not replace
+        process_single_position(
+            func=dummy_transform,
+            input_position_path=input_store_path / Path("A", "1", "0"),
+            output_position_path=output_store_path / Path("A", "1", "0"),
+            input_channel_indices=[[0]],
+            output_channel_indices=[[0]],
+            input_time_indices=[0],
+            output_time_indices=[0],
+            constant=2,
+            extra_metadata=new_metadata,
+        )
+
+        with open_ome_zarr(
+            output_store_path / "A/1/0", layout="fov", mode="r"
+        ) as pos:
+            result = pos.zattrs["extra_metadata"]
+            assert result == {"deskew": {"angle": 30.0}, "flat_field": {"method": "basic"}}
+
+
 @pytest.mark.parametrize(
     ("env", "expected_min", "expected_max"),
     [


### PR DESCRIPTION
## Summary

`process_single_position` unconditionally overwrites `extra_metadata` on the output position's zattrs, which causes two problems in multi-step pipelines:

1. **Clobber with `None`**: When no `extra_metadata` kwarg is passed, it writes `None`, destroying any metadata previously copied by `create_empty_plate`'s `metadata_sources` parameter (added in v0.3.7 / #419).

2. **Clobber with partial dict**: When `extra_metadata` is provided (e.g. `{"flat_field_correction": {...}}`), it replaces the entire existing dict rather than merging. In a pipeline like deskew → flat-field → reconstruct, each step's `extra_metadata` overwrites the previous step's keys.

### Fix

- When `extra_metadata` is **not provided**, existing metadata is left untouched.
- When `extra_metadata` is a **dict**, it is merged into any existing dict (new keys added, caller's keys take precedence).

### Context

Discovered while wiring `metadata_sources` through the [biahub PR cascade](https://github.com/czbiohub-sf/biahub/pull/255) (PRs #255–#266). The assembly/concatenation step copies metadata from 3 upstream plates via `metadata_sources`, then `process_single_position` immediately clobbers it with `None`. Upstream steps (flat-field, reconstruct) also lose prior steps' `extra_metadata` keys because the write is a full replacement.

A workaround is in place on the biahub side (read-back existing `extra_metadata` before calling `process_single_position`), but the root fix belongs here.

## Test plan

- [x] `test_process_single_position_preserves_existing_extra_metadata` — verifies omitting the kwarg preserves pre-existing metadata
- [x] `test_process_single_position_merges_extra_metadata` — verifies a new dict merges with pre-existing keys
- [x] Existing `test_process_single_position` still passes (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)