### PR TITLE
feat: store extra_metadata as top-level zattrs keys (alternative to #422)

### DIFF
--- a/src/iohub/ngff/utils.py
+++ b/src/iohub/ngff/utils.py
@@ -416,6 +416,8 @@ def process_single_position(
         overwriting one shared key. If a key is already present on the output
         position (e.g. copied from the input by ``create_empty_plate``'s
         ``metadata_sources``) it is overwritten and a warning is raised.
+        Reserved OME-Zarr keys (``ome``, ``multiscales``, ``omero``,
+        ``labels``, ``version``) are rejected with a ``ValueError``.
     """
     click.echo(f"Function to be applied: \t{func}")
     click.echo(f"Input data path:\t{input_position_path}")
@@ -470,6 +472,13 @@ def process_single_position(
     # clobbering upstream provenance.
     extra_metadata = kwargs.pop("extra_metadata", None)
     if extra_metadata:
+        reserved = _OME_KEYS.intersection(extra_metadata)
+        if reserved:
+            raise ValueError(
+                f"extra_metadata keys {sorted(reserved)} are reserved OME-Zarr "
+                f"keys and cannot be written as top-level zattrs. Use a "
+                f"namespaced key (e.g. '<package>-<step>') instead."
+            )
         with open_ome_zarr(output_position_path, layout="fov", mode="r+") as output_dataset:
             for key, value in extra_metadata.items():
                 if key in output_dataset.zattrs:

--- a/src/iohub/ngff/utils.py
+++ b/src/iohub/ngff/utils.py
@@ -6,7 +6,7 @@ import multiprocessing as mp
 import os
 import warnings
 from collections import defaultdict
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
 from functools import partial
 from pathlib import Path
@@ -471,7 +471,15 @@ def process_single_position(
     # create_empty_plate's metadata_sources) warns rather than silently
     # clobbering upstream provenance.
     extra_metadata = kwargs.pop("extra_metadata", None)
-    if extra_metadata:
+    if extra_metadata is not None:
+        if not isinstance(extra_metadata, Mapping):
+            raise TypeError(
+                f"extra_metadata must be a mapping, got "
+                f"{type(extra_metadata).__name__}."
+            )
+        non_string_keys = [key for key in extra_metadata if not isinstance(key, str)]
+        if non_string_keys:
+            raise TypeError(f"extra_metadata keys must be strings, got {non_string_keys}.")
         reserved = _OME_KEYS.intersection(extra_metadata)
         if reserved:
             raise ValueError(

--- a/src/iohub/ngff/utils.py
+++ b/src/iohub/ngff/utils.py
@@ -406,10 +406,10 @@ def process_single_position(
         Defaults to False.
     kwargs : dict, optional
         Additional arguments to pass to the function.
-        A dictionary with key "extra_metadata" can be passed to record
-        per-step provenance at the FOV level, typically a single namespaced
-        entry keyed by ``"<package>-<step>"``,
-        e.g. ``extra_metadata={"biahub-deskew": settings.model_dump()}``.
+        An ``extra_metadata`` kwarg (a dict) can be passed to record per-step
+        provenance at the FOV level, typically a single namespaced entry keyed
+        by ``"<package>-<step>"``, e.g.
+        ``extra_metadata={"biahub-deskew": settings.model_dump()}``.
         Each item is written as a separate top-level key on the output
         position's zattrs (*not* nested under an ``extra_metadata`` key), so
         successive steps accumulate sibling provenance keys instead of

--- a/src/iohub/ngff/utils.py
+++ b/src/iohub/ngff/utils.py
@@ -405,18 +405,28 @@ def process_single_position(
         Defaults to False.
     kwargs : dict, optional
         Additional arguments to pass to the function.
-        A dictionary with key "extra_metadata"
-        can be passed to be stored at a FOV level,
-        e.g.,
-        kwargs={"extra_metadata": {"Temperature": 37.5, "CO2_level": 0.5}}.
-        Each item of the ``extra_metadata`` dict is written as a separate
-        top-level key on the output position's zattrs (e.g. ``Temperature``
-        and ``CO2_level`` above), not nested under an ``extra_metadata`` key.
-        This lets successive processing steps accumulate sibling provenance
-        keys instead of overwriting a single shared key. Any keys already
-        present on the output position (e.g. copied by
-        ``create_empty_plate``'s ``metadata_sources``) are preserved unless
-        the same key is provided here.
+        A dictionary with key "extra_metadata" can be passed to record
+        per-step provenance at the FOV level. Each item of the
+        ``extra_metadata`` dict is written as a separate top-level key on the
+        output position's zattrs, *not* nested under an ``extra_metadata`` key.
+        Typically each processing step contributes a single namespaced entry
+        keyed by ``"<package>-<step>"`` whose value is the step's
+        configuration, e.g. a deskew step that reads a flat-field-corrected
+        input::
+
+            process_single_position(
+                deskew_czyx,
+                input_position_path,   # already carries "biahub-flat_field"
+                output_position_path,
+                extra_metadata={"biahub-deskew": settings.model_dump()},
+            )
+
+        Because entries are written as top-level keys, successive steps
+        accumulate sibling provenance keys (here ``biahub-flat_field`` and
+        ``biahub-deskew``) instead of overwriting one shared key. Keys already
+        present on the output position (e.g. copied from the input by
+        ``create_empty_plate``'s ``metadata_sources``) are preserved unless the
+        same key is passed here, in which case it is overwritten.
     """
     click.echo(f"Function to be applied: \t{func}")
     click.echo(f"Input data path:\t{input_position_path}")

--- a/src/iohub/ngff/utils.py
+++ b/src/iohub/ngff/utils.py
@@ -78,8 +78,9 @@ def create_empty_plate(
     metadata_sources : Path or str or list of Path or str, optional
         Path(s) to one or more source HCS plates from which to copy
         per-position metadata. When set, any custom (non-OME) zattrs
-        (e.g. ``extra_metadata``) are transferred from matching positions in
-        the source plate(s). Metadata is only transferred for newly created
+        (e.g. provenance keys such as ``biahub-flat_field``) are transferred
+        from matching positions in the source plate(s). Metadata is only
+        transferred for newly created
         positions, and a given zattrs key is only copied if it does not
         already exist on the destination position (so earlier sources take
         precedence over later ones). Coordinate transforms, axis definitions,
@@ -408,6 +409,14 @@ def process_single_position(
         can be passed to be stored at a FOV level,
         e.g.,
         kwargs={"extra_metadata": {"Temperature": 37.5, "CO2_level": 0.5}}.
+        Each item of the ``extra_metadata`` dict is written as a separate
+        top-level key on the output position's zattrs (e.g. ``Temperature``
+        and ``CO2_level`` above), not nested under an ``extra_metadata`` key.
+        This lets successive processing steps accumulate sibling provenance
+        keys instead of overwriting a single shared key. Any keys already
+        present on the output position (e.g. copied by
+        ``create_empty_plate``'s ``metadata_sources``) are preserved unless
+        the same key is provided here.
     """
     click.echo(f"Function to be applied: \t{func}")
     click.echo(f"Input data path:\t{input_position_path}")
@@ -453,10 +462,17 @@ def process_single_position(
             a time index beyond the maximum index of
             the dataset = {time_ubound}""")
 
-    # Write extra metadata to the output store
+    # Write extra metadata to the output store. Each entry is stored as a
+    # top-level zattrs key rather than nested under a single "extra_metadata"
+    # key, so successive processing steps record their provenance as sibling
+    # keys (e.g. "biahub-flat_field", "biahub-deskew") instead of overwriting
+    # one shared key. Existing keys (e.g. metadata copied by
+    # create_empty_plate's metadata_sources) are preserved.
     extra_metadata = kwargs.pop("extra_metadata", None)
-    with open_ome_zarr(output_position_path, layout="fov", mode="r+") as output_dataset:
-        output_dataset.zattrs["extra_metadata"] = extra_metadata
+    if extra_metadata:
+        with open_ome_zarr(output_position_path, layout="fov", mode="r+") as output_dataset:
+            for key, value in extra_metadata.items():
+                output_dataset.zattrs[key] = value
 
     # Loop through (T, C), applying transform and writing as we go
     iterable = itertools.product(

--- a/src/iohub/ngff/utils.py
+++ b/src/iohub/ngff/utils.py
@@ -4,6 +4,7 @@ import inspect
 import itertools
 import multiprocessing as mp
 import os
+import warnings
 from collections import defaultdict
 from collections.abc import Callable, Sequence
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
@@ -406,27 +407,15 @@ def process_single_position(
     kwargs : dict, optional
         Additional arguments to pass to the function.
         A dictionary with key "extra_metadata" can be passed to record
-        per-step provenance at the FOV level. Each item of the
-        ``extra_metadata`` dict is written as a separate top-level key on the
-        output position's zattrs, *not* nested under an ``extra_metadata`` key.
-        Typically each processing step contributes a single namespaced entry
-        keyed by ``"<package>-<step>"`` whose value is the step's
-        configuration, e.g. a deskew step that reads a flat-field-corrected
-        input::
-
-            process_single_position(
-                deskew_czyx,
-                input_position_path,   # already carries "biahub-flat_field"
-                output_position_path,
-                extra_metadata={"biahub-deskew": settings.model_dump()},
-            )
-
-        Because entries are written as top-level keys, successive steps
-        accumulate sibling provenance keys (here ``biahub-flat_field`` and
-        ``biahub-deskew``) instead of overwriting one shared key. Keys already
-        present on the output position (e.g. copied from the input by
-        ``create_empty_plate``'s ``metadata_sources``) are preserved unless the
-        same key is passed here, in which case it is overwritten.
+        per-step provenance at the FOV level, typically a single namespaced
+        entry keyed by ``"<package>-<step>"``,
+        e.g. ``extra_metadata={"biahub-deskew": settings.model_dump()}``.
+        Each item is written as a separate top-level key on the output
+        position's zattrs (*not* nested under an ``extra_metadata`` key), so
+        successive steps accumulate sibling provenance keys instead of
+        overwriting one shared key. If a key is already present on the output
+        position (e.g. copied from the input by ``create_empty_plate``'s
+        ``metadata_sources``) it is overwritten and a warning is raised.
     """
     click.echo(f"Function to be applied: \t{func}")
     click.echo(f"Input data path:\t{input_position_path}")
@@ -476,12 +465,19 @@ def process_single_position(
     # top-level zattrs key rather than nested under a single "extra_metadata"
     # key, so successive processing steps record their provenance as sibling
     # keys (e.g. "biahub-flat_field", "biahub-deskew") instead of overwriting
-    # one shared key. Existing keys (e.g. metadata copied by
-    # create_empty_plate's metadata_sources) are preserved.
+    # one shared key. Overwriting a pre-existing key (e.g. metadata copied by
+    # create_empty_plate's metadata_sources) warns rather than silently
+    # clobbering upstream provenance.
     extra_metadata = kwargs.pop("extra_metadata", None)
     if extra_metadata:
         with open_ome_zarr(output_position_path, layout="fov", mode="r+") as output_dataset:
             for key, value in extra_metadata.items():
+                if key in output_dataset.zattrs:
+                    warnings.warn(
+                        f"extra_metadata key {key!r} already exists on "
+                        f"{output_position_path} and will be overwritten.",
+                        stacklevel=2,
+                    )
                 output_dataset.zattrs[key] = value
 
     # Loop through (T, C), applying transform and writing as we go

--- a/tests/ngff/test_ngff_utils.py
+++ b/tests/ngff/test_ngff_utils.py
@@ -1097,6 +1097,22 @@ def test_process_single_position(setup, constant, num_workers, use_threads):
                 )
 
 
+def test_process_single_position_rejects_reserved_ome_keys():
+    """extra_metadata keys colliding with reserved OME-Zarr keys raise."""
+    shape = (1, 1, 2, 4, 4)
+    with TemporaryDirectory() as temp_dir:
+        store_path = Path(temp_dir) / "test.zarr"
+        create_empty_plate(store_path, [("A", "1", "0")], ["c"], shape)
+        position_path = store_path / "A" / "1" / "0"
+        with pytest.raises(ValueError, match="reserved OME-Zarr"):
+            process_single_position(
+                func=lambda x: x,
+                input_position_path=position_path,
+                output_position_path=position_path,
+                extra_metadata={"multiscales": {"oops": 1}},
+            )
+
+
 @pytest.mark.parametrize(
     ("env", "expected_min", "expected_max"),
     [

--- a/tests/ngff/test_ngff_utils.py
+++ b/tests/ngff/test_ngff_utils.py
@@ -469,9 +469,11 @@ def verify_transformation(
         # Extract extra metadata if provided
         extra_metadata = kwargs.pop("extra_metadata", None)
 
-        # Check if extra_metadata is provided
+        # Each extra_metadata entry is written as a top-level zattrs key,
+        # not nested under an "extra_metadata" key.
         if extra_metadata is not None:
-            assert output_position.zattrs["extra_metadata"] == extra_metadata
+            for key, value in extra_metadata.items():
+                assert output_position.zattrs[key] == value
 
         # Check the transformation for each time point and channel
         input_data = input_position.data.oindex[time_indices, channel_indices]

--- a/tests/ngff/test_ngff_utils.py
+++ b/tests/ngff/test_ngff_utils.py
@@ -1113,6 +1113,29 @@ def test_process_single_position_rejects_reserved_ome_keys():
             )
 
 
+
+def test_process_single_position_warns_on_overwrite_of_existing_zattrs_key():
+    shape = (1, 1, 1, 2, 2)
+    with TemporaryDirectory() as temp_dir:
+        store_path = Path(temp_dir) / "test.zarr"
+        create_empty_plate(store_path, [("A", "1", "0")], ["c"], shape)
+        position_path = store_path / "A" / "1" / "0"
+
+        with open_ome_zarr(position_path, layout="fov", mode="r+") as pos:
+            pos.zattrs["biahub-test"] = {"v": 1}
+
+        with pytest.warns(UserWarning, match="will be overwritten"):
+            process_single_position(
+                func=lambda x: x,
+                input_position_path=position_path,
+                output_position_path=position_path,
+                extra_metadata={"biahub-test": {"v": 2}},
+                num_workers=1,
+            )
+
+        with open_ome_zarr(position_path, layout="fov", mode="r") as pos:
+            assert pos.zattrs["biahub-test"] == {"v": 2}
+
 @pytest.mark.parametrize(
     ("env", "expected_min", "expected_max"),
     [

--- a/tests/ngff/test_ngff_utils.py
+++ b/tests/ngff/test_ngff_utils.py
@@ -474,6 +474,8 @@ def verify_transformation(
         if extra_metadata is not None:
             for key, value in extra_metadata.items():
                 assert output_position.zattrs[key] == value
+            # The legacy wrapper key must not be written.
+            assert "extra_metadata" not in dict(output_position.zattrs)
 
         # Check the transformation for each time point and channel
         input_data = input_position.data.oindex[time_indices, channel_indices]
@@ -1113,6 +1115,28 @@ def test_process_single_position_rejects_reserved_ome_keys():
             )
 
 
+def test_process_single_position_rejects_invalid_extra_metadata():
+    """Non-mapping or non-string-keyed extra_metadata raises TypeError."""
+    shape = (1, 1, 2, 4, 4)
+    with TemporaryDirectory() as temp_dir:
+        store_path = Path(temp_dir) / "test.zarr"
+        create_empty_plate(store_path, [("A", "1", "0")], ["c"], shape)
+        position_path = store_path / "A" / "1" / "0"
+        with pytest.raises(TypeError, match="must be a mapping"):
+            process_single_position(
+                func=lambda x: x,
+                input_position_path=position_path,
+                output_position_path=position_path,
+                extra_metadata=["not", "a", "mapping"],
+            )
+        with pytest.raises(TypeError, match="must be strings"):
+            process_single_position(
+                func=lambda x: x,
+                input_position_path=position_path,
+                output_position_path=position_path,
+                extra_metadata={1: {"oops": 1}},
+            )
+
 
 def test_process_single_position_warns_on_overwrite_of_existing_zattrs_key():
     shape = (1, 1, 1, 2, 2)
@@ -1135,6 +1159,7 @@ def test_process_single_position_warns_on_overwrite_of_existing_zattrs_key():
 
         with open_ome_zarr(position_path, layout="fov", mode="r") as pos:
             assert pos.zattrs["biahub-test"] == {"v": 2}
+
 
 @pytest.mark.parametrize(
     ("env", "expected_min", "expected_max"),


### PR DESCRIPTION
## Summary

An **alternative implementation to #422**. Both PRs address the same root problem: `process_single_position` overwrites the output position's `extra_metadata` zattr, so in multi-step pipelines each step clobbers the previous step's provenance (and metadata copied by `create_empty_plate`'s `metadata_sources`, added in #419).

Where #422 keeps the single `extra_metadata` key and **merges** dicts into it, this PR removes the shared wrapper key entirely:

- Each item of the `extra_metadata` dict is written as a **separate top-level key** on the position's zattrs (e.g. `biahub-flat_field`, `biahub-deskew`) instead of being nested under one `extra_metadata` key.
- Successive steps therefore accumulate **sibling** provenance keys; there is no shared dict for a later step to overwrite, so the duplicate-field / clobbering problem cannot arise by construction.
- `create_empty_plate`'s `metadata_sources` copy already carries top-level custom (non-OME) keys forward, so upstream provenance is inherited without changes there.
- If a step writes a key that **already exists** on the output position, it is overwritten and a `UserWarning` is raised rather than silently clobbering (genuine re-processing or a key collision).

### Trade-offs vs #422

- **Pro:** no nesting, no merge logic, no possibility of two steps fighting over one `extra_metadata` key; provenance reads as flat, self-describing keys.
- **Con:** custom keys live at the top level of zattrs alongside OME keys, so callers should namespace them (the `"<package>-<step>"` convention, e.g. `biahub-deskew`) to avoid collisions. OME-spec keys are never touched.

### Context

Same cascade as #422 — wiring `metadata_sources` through the [biahub PR cascade](https://github.com/czbiohub-sf/biahub/pull/255). With this approach the biahub side needs no read-back workaround; steps just pass `extra_metadata={"biahub-<step>": settings.model_dump()}` and the keys land side by side.

## Test plan

- [x] `tests/ngff/test_ngff_utils.py` — updated the `process_single_position` assertion to check each entry as a top-level key; full file passes (30 passed).
- [x] `metadata_sources` tests unchanged and passing (they exercise `create_empty_plate`'s generic top-level copy).
- [x] Manually verified end-to-end: flat-field output carries top-level `biahub-flat_field`; deskew output carries both `biahub-flat_field` (inherited) and `biahub-deskew`; overwrite warning fires only on key collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)