### PR TITLE
fix(downsample): cover odd-sized axes when building pyramid levels

### DIFF
--- a/src/iohub/core/downsample.py
+++ b/src/iohub/core/downsample.py
@@ -8,7 +8,7 @@ import numpy as np
 
 
 def downsample_block(data: np.ndarray, factors: list[int], method: str) -> np.ndarray:
-    """Downsample an N-D numpy block by integer factors.
+    """Downsample an N-D numpy block by integer factors (1 = pass through).
 
     Axes whose size is not an exact multiple of the corresponding factor
     are edge-padded up to the next multiple before pooling, so the output
@@ -16,22 +16,6 @@ def downsample_block(data: np.ndarray, factors: list[int], method: str) -> np.nd
     block on such an axis is averaged together with the boundary value,
     which matches the ceiling-division shape that ``initialize_pyramid``
     allocates for downstream pyramid levels.
-
-    Parameters
-    ----------
-    data : numpy.ndarray
-        Source block.
-    factors : list of int
-        Integer downsample factor per axis. Use 1 for axes that should pass
-        through unchanged.
-    method : str
-        Aggregation method: ``"mean"``, ``"median"``, ``"min"``, ``"max"``,
-        ``"mode"``, or ``"stride"``.
-
-    Returns
-    -------
-    numpy.ndarray
-        Downsampled block with shape ``tuple(ceil(s / f) for s, f in zip(data.shape, factors))``.
     """
     if method == "stride":
         return data[tuple(slice(None, None, f) for f in factors)]

--- a/src/iohub/core/downsample.py
+++ b/src/iohub/core/downsample.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import itertools
 
 import numpy as np
+from numpy.typing import NDArray
 
 
-def downsample_block(data: np.ndarray, factors: list[int], method: str) -> np.ndarray:
-    """Downsample an N-D numpy block by integer factors (1 = pass through).
+def downsample_block(data: NDArray, factors: list[int], method: str) -> NDArray:
+    """Downsample an N-D numpy block by integer factors.
 
     Axes whose size is not an exact multiple of the corresponding factor
     are edge-padded up to the next multiple before pooling, so the output
@@ -16,6 +17,22 @@ def downsample_block(data: np.ndarray, factors: list[int], method: str) -> np.nd
     block on such an axis is averaged together with the boundary value,
     which matches the ceiling-division shape that ``initialize_pyramid``
     allocates for downstream pyramid levels.
+
+    Parameters
+    ----------
+    data : NDArray
+        Source block.
+    factors : list of int
+        Integer downsample factor per axis. Use 1 for axes that should pass
+        through unchanged.
+    method : str
+        Aggregation method: ``"mean"``, ``"median"``, ``"min"``, ``"max"``,
+        ``"mode"``, or ``"stride"``.
+
+    Returns
+    -------
+    NDArray
+        Downsampled block with shape ``tuple(ceil(s / f) for s, f in zip(data.shape, factors))``.
     """
     if method == "stride":
         return data[tuple(slice(None, None, f) for f in factors)]

--- a/src/iohub/core/downsample.py
+++ b/src/iohub/core/downsample.py
@@ -8,12 +8,37 @@ import numpy as np
 
 
 def downsample_block(data: np.ndarray, factors: list[int], method: str) -> np.ndarray:
-    """Downsample an N-D numpy block by integer factors."""
-    trim_slices = tuple(slice(0, (s // f) * f) for s, f in zip(data.shape, factors, strict=False))
-    data = data[trim_slices]
+    """Downsample an N-D numpy block by integer factors.
 
+    Axes whose size is not an exact multiple of the corresponding factor
+    are edge-padded up to the next multiple before pooling, so the output
+    shape is the ceiling division ``ceil(s / f)``. The trailing partial
+    block on such an axis is averaged together with the boundary value,
+    which matches the ceiling-division shape that ``initialize_pyramid``
+    allocates for downstream pyramid levels.
+
+    Parameters
+    ----------
+    data : numpy.ndarray
+        Source block.
+    factors : list of int
+        Integer downsample factor per axis. Use 1 for axes that should pass
+        through unchanged.
+    method : str
+        Aggregation method: ``"mean"``, ``"median"``, ``"min"``, ``"max"``,
+        ``"mode"``, or ``"stride"``.
+
+    Returns
+    -------
+    numpy.ndarray
+        Downsampled block with shape ``tuple(ceil(s / f) for s, f in zip(data.shape, factors))``.
+    """
     if method == "stride":
         return data[tuple(slice(None, None, f) for f in factors)]
+
+    pad_widths = tuple((0, (-s) % f) for s, f in zip(data.shape, factors, strict=False))
+    if any(after > 0 for _, after in pad_widths):
+        data = np.pad(data, pad_widths, mode="edge")
 
     new_shape = []
     reduce_axes = []

--- a/src/iohub/core/implementations/zarr_python.py
+++ b/src/iohub/core/implementations/zarr_python.py
@@ -168,15 +168,16 @@ class ZarrPythonImplementation(ZarrImplementation[zarr.Group, zarr.Array]):
         factors: list[int],
         method: str = "mean",
     ) -> None:
-        """Read, downsample, and write a single shard-aligned region."""
+        """Read, downsample, and write a single shard-aligned region.
+
+        The caller-supplied ``factors`` are passed through to
+        ``downsample_block``. Partial trailing blocks on odd-sized source
+        axes are handled inside ``downsample_block`` by edge padding so the
+        downsampled output matches the ceiling-division target region shape.
+        """
         source_region = target_region_to_source(target_region, factors, source.shape)
         source_data = np.asarray(source[source_region])
-        local_factors = []
-        for sl_src, sl_tgt, f in zip(source_region, target_region, factors, strict=False):
-            src_size = sl_src.stop - sl_src.start
-            tgt_size = sl_tgt.stop - sl_tgt.start
-            local_factors.append(max(1, src_size // tgt_size) if tgt_size > 0 else f)
-        downsampled = downsample_block(source_data, local_factors, method)
+        downsampled = downsample_block(source_data, factors, method)
         target[target_region] = downsampled
 
     def iter_work_regions(self, target: zarr.Array) -> list[tuple[slice, ...]]:

--- a/src/iohub/core/implementations/zarr_python.py
+++ b/src/iohub/core/implementations/zarr_python.py
@@ -168,11 +168,7 @@ class ZarrPythonImplementation(ZarrImplementation[zarr.Group, zarr.Array]):
         factors: list[int],
         method: str = "mean",
     ) -> None:
-        """Read, downsample, and write a single shard-aligned region.
-
-        Factors pass through to ``downsample_block`` unchanged; recomputing a
-        per-region factor reintroduces the odd-axis truncation bug.
-        """
+        """Read, downsample, and write a single shard-aligned region."""
         source_region = target_region_to_source(target_region, factors, source.shape)
         source_data = np.asarray(source[source_region])
         downsampled = downsample_block(source_data, factors, method)

--- a/src/iohub/core/implementations/zarr_python.py
+++ b/src/iohub/core/implementations/zarr_python.py
@@ -170,10 +170,8 @@ class ZarrPythonImplementation(ZarrImplementation[zarr.Group, zarr.Array]):
     ) -> None:
         """Read, downsample, and write a single shard-aligned region.
 
-        The caller-supplied ``factors`` are passed through to
-        ``downsample_block``. Partial trailing blocks on odd-sized source
-        axes are handled inside ``downsample_block`` by edge padding so the
-        downsampled output matches the ceiling-division target region shape.
+        Factors pass through to ``downsample_block`` unchanged; recomputing a
+        per-region factor reintroduces the odd-axis truncation bug.
         """
         source_region = target_region_to_source(target_region, factors, source.shape)
         source_data = np.asarray(source[source_region])

--- a/tests/ngff/test_ngff.py
+++ b/tests/ngff/test_ngff.py
@@ -1758,15 +1758,20 @@ def test_downsample_block_odd_axis():
 def test_compute_pyramid_odd_axis(tmp_path, implementation):
     """Regression: pyramid mean-pool covers the full extent of an odd source axis.
 
-    The zarr-python backend previously recomputed a per-region "local
-    factor" from ``src_size // tgt_size`` inside ``downsample_region``.
-    When the source axis was odd (for example X=21 -> target L1 X=11),
-    floor division collapsed the X factor from 2 to 1, so the downsampled
-    block kept its full X resolution and zarr-python truncated the
-    assignment to the leading ``tgt_size`` columns. The second half of
-    the axis was silently discarded. This test puts a strictly increasing
-    ramp along X and asserts that the last L1 column tracks the last L0
-    column rather than capping at the L0 midpoint.
+    The zarr-python backend (and zarrs-python, which subclasses it)
+    previously recomputed a per-region "local factor" from
+    ``src_size // tgt_size`` inside ``downsample_region``. When the source
+    axis was odd (for example X=21 -> target L1 X=11), floor division
+    collapsed the X factor from 2 to 1, so the downsampled block kept its
+    full X resolution and zarr-python truncated the assignment to the
+    leading ``tgt_size`` columns. The second half of the axis was silently
+    discarded. This test puts a strictly increasing ramp along X and asserts
+    that the last L1 column tracks the last L0 column rather than capping at
+    the L0 midpoint.
+
+    tensorstore uses its own native ``ts.downsample`` path (never had the
+    bug), but is parametrized here because it is the primary pyramiding
+    backend and must hold the same odd-axis contract.
     """
     if implementation == "tensorstore":
         pytest.importorskip("tensorstore")

--- a/tests/ngff/test_ngff.py
+++ b/tests/ngff/test_ngff.py
@@ -1732,6 +1732,69 @@ def test_compute_pyramid(tmp_path, implementation):
             pos.compute_pyramid(levels=2, method="mean")
 
 
+def test_downsample_block_odd_axis():
+    """downsample_block edge-pads a trailing partial block instead of trimming.
+
+    Regression for a bug in which ``downsample_block`` trimmed the last
+    partial block on an odd-sized axis, producing an output one column
+    shorter than the pyramid level allocated by ``initialize_pyramid``
+    (which uses ceiling division).
+    """
+    from iohub.core.downsample import downsample_block
+
+    data = np.arange(21, dtype=np.float32).reshape(1, 21)  # ramp along X
+    out = downsample_block(data, [1, 2], "mean")
+
+    assert out.shape == (1, 11)
+    assert out[0, 0] == 0.5  # mean(0, 1)
+    assert out[0, 1] == 2.5  # mean(2, 3)
+    # Last bin pools the trailing single column [20] with an edge-pad
+    # copy of itself, so the result is 20.0 rather than missing (old
+    # trim behaviour) or 10.0 (the original "left half only" bug).
+    assert out[0, -1] == 20.0
+
+
+@pytest.mark.parametrize("implementation", ["zarrs-python", "tensorstore"])
+def test_compute_pyramid_odd_axis(tmp_path, implementation):
+    """Regression: pyramid mean-pool covers the full extent of an odd source axis.
+
+    The zarr-python backend previously recomputed a per-region "local
+    factor" from ``src_size // tgt_size`` inside ``downsample_region``.
+    When the source axis was odd (for example X=21 -> target L1 X=11),
+    floor division collapsed the X factor from 2 to 1, so the downsampled
+    block kept its full X resolution and zarr-python truncated the
+    assignment to the leading ``tgt_size`` columns. The second half of
+    the axis was silently discarded. This test puts a strictly increasing
+    ramp along X and asserts that the last L1 column tracks the last L0
+    column rather than capping at the L0 midpoint.
+    """
+    if implementation == "tensorstore":
+        pytest.importorskip("tensorstore")
+    store_path = tmp_path / "test_pyramid_odd_x.zarr"
+
+    Z, Y, X = 4, 6, 21  # Y even, X odd; only X exposes the bug
+    ramp = np.arange(X, dtype=np.float32).reshape(1, 1, 1, 1, X)
+    data = np.broadcast_to(ramp, (1, 1, Z, Y, X)).copy()
+
+    with open_ome_zarr(
+        store_path,
+        layout="fov",
+        mode="a",
+        channel_names=["ch0"],
+        implementation=implementation,
+    ) as pos:
+        pos.create_image("0", data)
+        pos.compute_pyramid(levels=2, method="mean", dims={"y", "x"})
+        L1 = np.asarray(pos["1"][:])
+
+    assert L1.shape == (1, 1, Z, 3, 11)
+    # First L1 X column averages L0 X=0,1 -> 0.5; last averages the
+    # trailing X=20 with an edge-pad copy of itself -> 20.0. The bug
+    # would put the L0 midpoint (~10) in the last column.
+    assert L1[..., 0].mean() == pytest.approx(0.5)
+    assert L1[..., -1].mean() == pytest.approx(20.0)
+
+
 @pytest.mark.parametrize("implementation", ["zarrs-python", "tensorstore"])
 def test_delete_pyramid(tmp_path, implementation):
     """Test delete_pyramid removes all pyramid levels except level 0."""


### PR DESCRIPTION
**Summary**

When `compute_pyramid` (or any caller of `downsample_region` in the zarr-python
backend) operated on a source axis whose size was not an exact multiple of the
requested factor, the trailing half of that axis was silently discarded.
For an L0 shape with odd X=2055 and a factor-2 X downsample, L1 stored only
the leftmost 1028 columns of the Y-mean of L0 instead of a 2x2-pooled image.
At higher zoom napari then spread those leftmost columns across the full
world extent, producing visible X-stretching in OME-Zarr pyramids.

Surfaced while inspecting the daxi reconstruction sweep at
`/hpc/projects/waveorder/tile-stitch/runs/fused_sweep_iso_viz/` (L0 shape
`(2372, 2244, 2055)`, X is odd), generated by `iohub.compute_pyramid(dims={"y", "x"})`
via the `viz_pyramid.py` wrapper. Every store in the sweep had the same
left-half-only L1+ on the X axis.

**Root cause**

`ZarrPythonImplementation.downsample_region` recomputed a "local factor" per
region from `max(1, src_size // tgt_size)`. For the rightmost target region
on an odd-sized axis, `target_region_to_source` correctly clipped the source
slice to the array boundary, giving `src_size = 2055` and `tgt_size = 1028`.
Floor division then returned `1` instead of `2`, so `downsample_block`
returned a (1122, 2055) block. Zarr-python truncated that assignment to the
(1122, 1028) target region, keeping only the leftmost half of the source.

`downsample_block` itself also trimmed odd trailing blocks instead of covering
them, which independently disagrees with the ceiling-division shape that
`initialize_pyramid` allocates per level.

**Fix**

- `downsample_block` now edge-pads each axis up to the next multiple of its
  factor before pooling. Output shape is `ceil(s / f)`, matching the pyramid
  level shapes from `initialize_pyramid`.
- `downsample_region` no longer recomputes a per-region "local factor"; it
  passes the caller-supplied factors straight to `downsample_block`.

**Tests**

- `test_downsample_block_odd_axis`: pure-numpy regression for the trim vs.
  pad behaviour. A 21-wide ramp becomes an 11-wide averaged ramp whose last
  bin is 20.0 (edge-padded), not absent.
- `test_compute_pyramid_odd_axis`: end-to-end regression on a
  `(1, 1, 4, 6, 21)` zarr where Y is even and X is odd. L1's last X column
  equals 20.0 (correct edge-pad pool) instead of ~10 (left-half-only bug).