### PR TITLE
ci: update GitHub Actions and pin via sha

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # GitHub Actions only — keeps the SHA pins fresh. No pip/uv ecosystem (too noisy).
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,34 +6,43 @@ on:
   pull_request:
     branches: [main]
 
-permissions:
-  contents: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false # never cancel an in-flight docs deploy
 
 jobs:
   # Verify docs build cleanly on PRs
   build:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout only
     steps:
-      - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: "3.13"
-          enable-cache: true
+          enable-cache: false # privileged workflow; avoid cache-poisoning vector
       - run: uv sync --group doc
       - run: uv run zensical build --clean
 
   deploy:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # mike pushes built docs to the gh-pages branch
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: "3.13"
-          enable-cache: true
+          enable-cache: false # privileged workflow; avoid cache-poisoning vector
       - run: uv sync --group doc
       - run: git config user.name "github-actions[bot]"
       - run: git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,15 +6,24 @@ name: PR checks
 on:
   pull_request:
     branches:
-      - "*"
+      - "**"
+
+permissions:
+  contents: read # checkout source; token is read-only
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: j178/prek-action@v1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4
         with:
           extra-args: ''
 
@@ -25,10 +34,12 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -44,10 +55,22 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: "3.12"
           enable-cache: true
       - run: uv sync --group doc
       - run: uv run zensical build --clean
+
+  all-green:
+    name: All checks green
+    if: always()
+    needs: [lint, tests, docs]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read # checkout source; token is read-only
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: ${{ matrix.platform }} py${{ matrix.python-version }}
@@ -15,10 +22,12 @@ jobs:
         platform: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,28 @@
+name: zizmor
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload SARIF to code scanning
+      contents: read # checkout the repository
+      actions: read # resolve workflow and action definitions
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          persona: pedantic

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,27 @@
+rules:
+  # Require every action to be pinned to a full commit SHA.
+  unpinned-uses:
+    config:
+      policies:
+        "*": hash-pin
+  # Only allow actions from these trusted owners; add new owners deliberately.
+  forbidden-uses:
+    config:
+      allow:
+        - actions/*
+        - astral-sh/*
+        - j178/*
+        - re-actors/*
+        - zizmorcore/*
+  # python-version / platform come from the in-workflow matrix, not external input.
+  template-injection:
+    ignore:
+      - test.yml
+      - pr.yml
+  # docs.yml's deploy job intentionally persists credentials to push docs via mike.
+  artipacked:
+    ignore:
+      - docs.yml
+  # Requiring an explicit name on every job/step is stylistic noise for this repo.
+  anonymous-definition:
+    disable: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,8 @@ repos:
       - id: ruff-check
         args: [--fix]
       - id: ruff-format
+# GitHub Actions static analysis
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.26.1
+    hooks:
+      - id: zizmor

--- a/tests/ngff/test_xarray.py
+++ b/tests/ngff/test_xarray.py
@@ -127,7 +127,6 @@ def _make_position(rng, tmp_dir, channel_names, shape, scales=None, name="test.z
 @given(params=_xarray_roundtrip_params())
 @settings(
     max_examples=16,
-    deadline=2000,
     suppress_health_check=[
         HealthCheck.data_too_large,
         HealthCheck.function_scoped_fixture,
@@ -159,7 +158,6 @@ def test_roundtrip_data_and_scales(rng, params):
 @given(time_unit=time_unit_st, space_unit=space_unit_st)
 @settings(
     max_examples=16,
-    deadline=2000,
     suppress_health_check=[HealthCheck.function_scoped_fixture],
 )
 def test_roundtrip_coordinate_units(rng, time_unit, space_unit):
@@ -183,7 +181,6 @@ def test_roundtrip_coordinate_units(rng, time_unit, space_unit):
 @given(attrs=json_attrs_st)
 @settings(
     max_examples=16,
-    deadline=2000,
     suppress_health_check=[HealthCheck.function_scoped_fixture],
 )
 def test_roundtrip_value_attrs(rng, attrs):
@@ -210,7 +207,6 @@ def test_roundtrip_value_attrs(rng, attrs):
 @given(params=_xarray_roundtrip_params())
 @settings(
     max_examples=16,
-    deadline=2000,
     suppress_health_check=[
         HealthCheck.data_too_large,
         HealthCheck.function_scoped_fixture,
@@ -246,7 +242,6 @@ def test_write_channel_subset(rng, params):
 @given(params=_xarray_roundtrip_params())
 @settings(
     max_examples=16,
-    deadline=2000,
     suppress_health_check=[
         HealthCheck.data_too_large,
         HealthCheck.function_scoped_fixture,


### PR DESCRIPTION
Also sets up Zizmor to check Github Actions configs, and removed `deadline` from tests as test performance on windows isn't consistent.