### PR TITLE
Write a gapped time selection as contiguous runs

### DIFF
--- a/src/iohub/ngff/utils.py
+++ b/src/iohub/ngff/utils.py
@@ -316,22 +316,55 @@ def _echo_finished(
         click.echo(f"Finished writing t={time_index}, c={channel_index}")
 
 
+def _contiguous_runs(indices: Sequence[int]) -> list[slice]:
+    """Split ``indices`` into maximal runs of consecutive values.
+
+    Returns slices *into* ``indices`` rather than the values themselves, so one
+    call carves up both an index list and the data written at those indices.
+    """
+    runs: list[slice] = []
+    start = 0
+    for position in range(1, len(indices) + 1):
+        if position == len(indices) or indices[position] != indices[position - 1] + 1:
+            runs.append(slice(start, position))
+            start = position
+    return runs
+
+
 def _save_transformed(
-    transformed: NDArray | list[NDArray] | None,
+    transformed: list[NDArray],
     output_position_path: Path,
     output_channel_indices: list[int] | slice,
-    output_time_indices: int | list[int],
+    output_time_indices: list[int],
     write_unit: WriteUnit | None = None,
 ) -> None:
+    """Write the transformed timepoints, one run of consecutive timepoints at a time.
+
+    The write has to be split because a *gapped* time selection is not
+    expressible as a slice, and a sharded write cannot be done without one:
+    the zarrs (Rust) codec pipeline rejects the selection with
+    ``DiscontiguousArrayError`` and falls back to a zarr-python path that
+    mismaps the value buffer onto the shard — indexing it with coordinates from
+    the shard's own space, which raises ``IndexError`` or, on a large array,
+    asks numpy for a preposterous allocation.
+
+    Gaps arise routinely once the output is sharded along T, because
+    :func:`process_single_position` then batches a whole shard's worth of
+    timepoints into one write and
+    :func:`apply_transform_to_tczyx_and_save` drops the ones whose input was
+    all zeros or NaNs from the middle of that batch. They also arise from a
+    caller asking for non-consecutive ``output_time_indices`` outright.
+    """
     with open_ome_zarr(output_position_path, layout="fov", mode="r+") as output_dataset:
         arr = output_dataset.data
         if write_unit is not None:
             write_unit.begin()
-        arr._impl.write_oindex(
-            arr.native,
-            (output_time_indices, output_channel_indices),
-            transformed,
-        )
+        for run in _contiguous_runs(output_time_indices):
+            arr._impl.write_oindex(
+                arr.native,
+                (output_time_indices[run], output_channel_indices),
+                transformed[run],
+            )
         if write_unit is not None:
             write_unit.complete()
 

--- a/tests/ngff/test_ngff_utils.py
+++ b/tests/ngff/test_ngff_utils.py
@@ -23,6 +23,7 @@ from iohub.ngff.models import LabelsMeta
 from iohub.ngff.utils import (
     _V05_DEFAULT_ZYX_CHUNKS,
     _available_cpus,
+    _contiguous_runs,
     _indices_to_shard_aligned_batches,
     _match_indices_to_batches,
     apply_transform_to_tczyx_and_save,
@@ -1528,6 +1529,113 @@ def test_apply_transform_to_tczyx_on_multi_channel_shard(tmp_path):
         in_slice = in_ds["/".join(position_key)].data[:1, :2]
         out_slice = out_ds["/".join(position_key)].data[:1, :2]
     np.testing.assert_array_almost_equal(out_slice, dummy_transform(in_slice, constant=2))
+
+
+# -- Gapped time selections on T-sharded stores -------------------------------
+#
+# Sharding along T makes ``process_single_position`` batch a shard's worth of
+# timepoints into a single write, and that write can end up addressing
+# non-consecutive timepoints: an all-zero or all-NaN input in the middle of the
+# batch is dropped, or the caller asks for non-consecutive indices outright.
+# A gapped selection is not expressible as a slice, which a sharded write
+# requires, so the write has to be split into runs of consecutive timepoints.
+
+
+@pytest.mark.parametrize(
+    ("indices", "expected"),
+    [
+        ([], []),
+        ([3], [slice(0, 1)]),
+        ([0, 1, 2, 3, 4], [slice(0, 5)]),
+        ([0, 3, 4], [slice(0, 1), slice(1, 3)]),  # the t=1,2-skipped case
+        ([0, 2, 4], [slice(0, 1), slice(1, 2), slice(2, 3)]),
+        ([5, 6, 9], [slice(0, 2), slice(2, 3)]),
+    ],
+)
+def test_contiguous_runs(indices, expected):
+    """``_contiguous_runs`` slices an index list at every gap."""
+    assert _contiguous_runs(indices) == expected
+
+
+def _t_sharded_stores(tmp_path, shape, position_key, shard_t):
+    """Input and output stores whose shards hold ``shard_t`` timepoints each."""
+    input_store = tmp_path / "input.zarr"
+    output_store = tmp_path / "output.zarr"
+    for store in (input_store, output_store):
+        create_empty_plate(
+            store_path=store,
+            position_keys=[position_key],
+            channel_names=[f"c{i}" for i in range(shape[1])],
+            shape=shape,
+            chunks=(1, 1, shape[2], shape[3] // 2, shape[4] // 2),
+            shards_ratio=(shard_t, 1, 1, 2, 2),
+            version="0.5",
+        )
+    return input_store, output_store
+
+
+def test_process_single_position_with_zero_timepoints_inside_a_t_shard(tmp_path):
+    """A dropped timepoint mid-batch must not break the shard-aligned write.
+
+    ``t=1`` and ``t=2`` are all zeros, so they are skipped and the surviving
+    output indices of the ``t=0..4`` batch are ``[0, 3, 4]`` — a gapped
+    selection. Regression test: this used to reach a zarr-python code path that
+    indexed the value buffer with the shard's own coordinates, raising
+    ``IndexError`` or attempting an absurd allocation.
+    """
+    shape = (5, 2, 4, 16, 16)
+    position_key = ("A", "1", "0")
+    input_store, output_store = _t_sharded_stores(tmp_path, shape, position_key, shard_t=5)
+    populate_store(input_store, [position_key], shape, np.float32)
+    with open_ome_zarr(input_store, mode="r+") as in_ds:
+        in_ds["/".join(position_key)].data[1:3] = 0
+
+    assert _open_array(output_store, position_key).shards[0] == 5
+
+    process_single_position(
+        func=dummy_transform,
+        input_position_path=input_store / Path(*position_key),
+        output_position_path=output_store / Path(*position_key),
+        input_channel_indices=[[0], [1]],
+        output_channel_indices=[[0], [1]],
+        input_time_indices=list(range(shape[0])),
+        output_time_indices=list(range(shape[0])),
+        constant=2,
+    )
+
+    with open_ome_zarr(input_store) as in_ds, open_ome_zarr(output_store) as out_ds:
+        in_data = in_ds["/".join(position_key)].data[:]
+        out_data = out_ds["/".join(position_key)].data[:]
+    # Skipped timepoints are left at the fill value; the rest are transformed.
+    expected = dummy_transform(in_data, constant=2)
+    np.testing.assert_array_almost_equal(out_data, expected)
+    assert not out_data[1:3].any()
+
+
+def test_apply_transform_to_tczyx_with_gapped_output_time_indices(tmp_path):
+    """A caller-requested gap within one T shard is written correctly."""
+    shape = (5, 1, 4, 16, 16)
+    position_key = ("A", "1", "0")
+    input_store, output_store = _t_sharded_stores(tmp_path, shape, position_key, shard_t=5)
+    populate_store(input_store, [position_key], shape, np.float32)
+
+    apply_transform_to_tczyx_and_save(
+        func=dummy_transform,
+        input_position_path=input_store / Path(*position_key),
+        output_position_path=output_store / Path(*position_key),
+        input_channel_indices=0,
+        output_channel_indices=0,
+        input_time_indices=[0, 2, 4],
+        output_time_indices=[0, 2, 4],
+        constant=2,
+    )
+
+    with open_ome_zarr(input_store) as in_ds, open_ome_zarr(output_store) as out_ds:
+        in_data = in_ds["/".join(position_key)].data[:]
+        out_data = out_ds["/".join(position_key)].data[:]
+    written = [0, 2, 4]
+    np.testing.assert_array_almost_equal(out_data[written], dummy_transform(in_data[written], constant=2))
+    assert not out_data[[1, 3]].any()
 
 
 # -- Interrupted-write repair and resume -----------------------------------


### PR DESCRIPTION
## The failure

Concatenating a `(67, 6, 86, 1664, 1193)` float32 plate with
`shards_ratio: [5, 1, 6, 7, 5]` died with:

```
numpy._core._exceptions._ArrayMemoryError: Unable to allocate 651. TiB for an
array with shape (1048576, 86, 1664, 1193) and data type float32
```

## Why

Sharding along T makes `process_single_position` batch a whole shard's worth of
timepoints into one write. `apply_transform_to_tczyx_and_save` then drops the
timepoints whose input is all zeros or NaNs — here `t=1` and `t=2` of the
`t=0..4` batch — and writes the survivors, `[0, 3, 4]`, in a single orthogonal
write. A caller asking for non-consecutive `output_time_indices` outright
produces the same shape of selection.

A gapped selection is not expressible as a slice, and a sharded write needs
one:

1. the zarrs pipeline rejects it — `DiscontiguousArrayError: [3 1]`, which is
   exactly `np.diff([0, 3, 4])`;
2. it falls back to zarr-python's partial-shard encode path, which reaches
   `chunk_value = value[out_selection]` with `out_selection` carrying
   coordinates from the *shard's* index space rather than the value buffer's.
   On a small array that is an `IndexError`; on a real one numpy is asked for
   the whole index space.

## The change

Split the write at every gap and write each run of consecutive timepoints
separately. Each run is sliceable, which both pipelines handle.

- The no-gap case — every batch where nothing was dropped — stays a single
  write, so the common path is unchanged.
- Peak memory is unchanged: the same buffers are written, in more than one
  call.
- `WriteUnit.begin()`/`complete()` still bracket the whole set of runs, so a
  kill mid-way leaves the in-flight marker and the unit is recomputed. Repair
  and resume behave as before.

## Tests

Two regression tests, both of which fail on `main` with the production
signature (`DiscontiguousArrayError` → `IndexError`) and pass here:

- `test_process_single_position_with_zero_timepoints_inside_a_t_shard` — blank
  `t=1,2` inside a 5-deep T shard, asserting the skipped timepoints stay at the
  fill value and the rest are transformed.
- `test_apply_transform_to_tczyx_with_gapped_output_time_indices` — a
  caller-requested gap within one T shard.

Plus a table-driven unit test for the `_contiguous_runs` helper.

`tests/ngff/test_ngff_utils.py` is otherwise green. The one failure,
`test_apply_transform_to_tczyx_and_save`, reproduces identically on unmodified
`main`: a zarrs `incompatible offset` error for a shard spanning multiple
*channels*, which is unrelated and not touched here.