### PR TITLE
Auto-size shards from a byte or spatial-extent target

### DIFF
--- a/docs/examples/run_update_ome_zarr.py
+++ b/docs/examples/run_update_ome_zarr.py
@@ -60,7 +60,10 @@ with open_ome_zarr(old_store_path, mode="r", layout="hcs") as old_dataset:
                 "0",
                 data=old_image.numpy(),
                 chunks=(1, 1, 4, 32, 32),
-                shards_ratio=(2, 1, 8, 4, 4),
+                # State the shard size you want and let iohub pick a chunk
+                # multiple that fits: "XYZ" for one shard per volume, or a
+                # target file size such as "2GB".
+                shards="XYZ",
                 transform=old_position.metadata.multiscales[0].datasets[0].coordinate_transformations,
             )
 
@@ -69,7 +72,7 @@ with open_ome_zarr(old_store_path, mode="r", layout="hcs") as old_dataset:
 with open_ome_zarr(new_store_path / "A/1/0", mode="r") as dataset:
     assert dataset.scale == scale
     image = dataset["0"]
-    assert image.shards == (2, 1, 32, 128, 128)
+    assert image.shards == (1, 1, 32, 128, 128)
     assert np.array_equal(image.numpy(), random_image)
 
 # %%

--- a/docs/examples/update_ome_zarr.md
+++ b/docs/examples/update_ome_zarr.md
@@ -59,7 +59,10 @@ with open_ome_zarr(old_store_path, mode="r", layout="hcs") as old_dataset:
                 "0",
                 data=old_image.numpy(),
                 chunks=(1, 1, 4, 32, 32),
-                shards_ratio=(2, 1, 8, 4, 4),
+                # State the shard size you want and let iohub pick a chunk
+                # multiple that fits: "XYZ" for one shard per volume, or a
+                # target file size such as "2GB".
+                shards="XYZ",
                 transform=old_position.metadata.multiscales[0]
                 .datasets[0]
                 .coordinate_transformations,
@@ -72,7 +75,7 @@ with open_ome_zarr(old_store_path, mode="r", layout="hcs") as old_dataset:
 with open_ome_zarr(new_store_path / "A/1/0", mode="r") as dataset:
     assert dataset.scale == scale
     image = dataset["0"]
-    assert image.shards == (2, 1, 32, 128, 128)
+    assert image.shards == (1, 1, 32, 128, 128)
     assert np.array_equal(image.numpy(), random_image)
 ```
 

--- a/src/iohub/core/__init__.py
+++ b/src/iohub/core/__init__.py
@@ -37,6 +37,12 @@ from iohub.core.registry import (
     register_implementation,
     set_default_implementation,
 )
+from iohub.core.sharding import (
+    ShardsLike,
+    parse_shard_size,
+    resolve_shard_shape,
+    resolve_shards,
+)
 from iohub.core.specs import ArraySpec
 from iohub.core.types import (
     AccessMode,
@@ -70,6 +76,8 @@ __all__ = [
     "OzxStore",
     "OzxSummary",
     "PathNormalizationError",
+    # Sharding
+    "ShardsLike",
     "StoreOpenError",
     "StorePath",
     "TensorStoreConfig",
@@ -85,8 +93,11 @@ __all__ = [
     "normalize_path",
     "pack_ozx",
     "pad_shape",
+    "parse_shard_size",
     "read_ozx_version",
     "register_implementation",
+    "resolve_shard_shape",
+    "resolve_shards",
     "set_default_implementation",
     "summarize_ozx",
     "unpack_ozx",

--- a/src/iohub/core/sharding.py
+++ b/src/iohub/core/sharding.py
@@ -1,0 +1,372 @@
+"""Resolve a shard geometry from the caller's intent.
+
+A zarr v3 shard must span a whole number of chunks, so choosing one by hand
+means computing a per-axis chunk multiple for every output shape. This module
+lets the caller state the intent instead -- a target file size (``"2GB"``) or a
+spatial extent (``"XYZ"``) -- and derives a shard shape that is chunk-aligned
+and no larger than the array.
+
+Two properties are deliberate, and only hold for the derived forms:
+
+- **Channels are never grown.** Sharding along the channel axis breaks
+  per-channel writes (see ``iohub.ngff.utils.process_single_position``), so the
+  channel axis always stays at one chunk.
+- **Spatial axes grow before time.** A torn shard costs everything it spans,
+  so a size target fills X, then Y, then Z before it spends any of the budget
+  on timepoints.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import re
+import warnings
+from collections.abc import Sequence
+
+import numpy as np
+from numpy.typing import DTypeLike
+
+_logger = logging.getLogger(__name__)
+
+#: What ``resolve_shards`` accepts: an explicit shard shape, a spatial extent
+#: keyword, a target size string, or None for no sharding.
+type ShardsLike = tuple[int, ...] | str | None
+
+#: Spatial extent keywords, mapped to the number of trailing axes they cover.
+#: Any letter order is accepted, so ``"ZYX"`` and ``"XYZ"`` are the same.
+_EXTENT_KEYWORDS: dict[frozenset[str], int] = {
+    frozenset("XY"): 2,
+    frozenset("XYZ"): 3,
+}
+
+#: Byte-size suffixes, both SI (``GB``) and binary (``GiB``).
+_SIZE_UNITS: dict[str, int] = {
+    "B": 1,
+    "KB": 10**3,
+    "MB": 10**6,
+    "GB": 10**9,
+    "TB": 10**12,
+    "KIB": 2**10,
+    "MIB": 2**20,
+    "GIB": 2**30,
+    "TIB": 2**40,
+}
+
+_SIZE_PATTERN = re.compile(r"^\s*(\d+(?:\.\d+)?)\s*([KMGT]I?B|B)?\s*$", re.IGNORECASE)
+
+#: Axis names treated as channel and time, compared case-insensitively.
+_CHANNEL_NAMES = frozenset({"c", "channel"})
+_TIME_NAMES = frozenset({"t", "time"})
+
+#: Axis names assumed when the caller does not pass any, aligned to the end of
+#: the shape. iohub arrays are TCZYX, so a 5D array without names is read as
+#: TCZYX and a lower-rank one as its trailing axes.
+_DEFAULT_AXIS_NAMES: tuple[str, ...] = ("t", "c", "z", "y", "x")
+
+
+def parse_shard_size(target: str) -> int:
+    """Parse a target size string into a number of bytes.
+
+    Accepts SI (``"2GB"`` = 2e9) and binary (``"2GiB"`` = 2**31) suffixes, and
+    a bare number as bytes. Case- and whitespace-insensitive.
+
+    Parameters
+    ----------
+    target : str
+        Size string, e.g. ``"2GB"``, ``"512 MiB"``, ``"1.5gb"``, ``"4096"``.
+
+    Returns
+    -------
+    int
+        Size in bytes.
+
+    Raises
+    ------
+    ValueError
+        If the string is not a number with an optional known suffix,
+        or if it resolves to zero bytes.
+    """
+    match = _SIZE_PATTERN.match(target)
+    if match is None:
+        raise ValueError(
+            f"Cannot parse shard size {target!r}. Expected a number with an optional "
+            f"unit, e.g. '2GB', '512MiB', or '1048576'."
+        )
+    value, unit = match.group(1), (match.group(2) or "B").upper()
+    nbytes = int(float(value) * _SIZE_UNITS[unit])
+    if nbytes < 1:
+        raise ValueError(f"Shard size {target!r} rounds to {nbytes} bytes, which cannot hold a chunk.")
+    return nbytes
+
+
+def resolve_shards(
+    shards: ShardsLike,
+    *,
+    shape: tuple[int, ...],
+    chunks: tuple[int, ...],
+    dtype: DTypeLike,
+    dimension_names: Sequence[str] | None = None,
+) -> tuple[int, ...] | None:
+    """Resolve a shard specification into a chunk-aligned shard shape.
+
+    Parameters
+    ----------
+    shards : tuple[int, ...] or str or None
+        The intent to resolve:
+
+        - ``None``: no sharding; returns None.
+        - tuple of int: an explicit shard shape in array elements. Entries are
+          rounded up to whole chunks, with a warning if that changes them.
+          Unlike the derived forms below, an explicit shape is taken as given
+          and may exceed the array.
+        - ``"XY"`` or ``"XYZ"``: one shard per plane or per volume. The
+          trailing 2 or 3 axes cover the whole array; every other axis stays
+          at one chunk.
+        - a size string such as ``"2GB"``: the largest chunk-aligned shard
+          whose nominal (uncompressed) size does not exceed the target. Axes
+          grow innermost-first -- X, then Y, then Z, then time -- and the
+          channel axis is never grown. Compression is not accounted for, so
+          the files on disk are typically smaller than the target.
+    shape : tuple[int, ...]
+        Array shape.
+    chunks : tuple[int, ...]
+        Chunk shape, same length as ``shape``.
+    dtype : DTypeLike
+        Array data type, used to convert a size target into element counts.
+    dimension_names : sequence of str, optional
+        Axis names, used to find the channel and time axes when growing into a
+        size target. When None, iohub's TCZYX order is assumed, aligned to the
+        end of the shape.
+
+    Returns
+    -------
+    tuple[int, ...] or None
+        Shard shape, or None when ``shards`` is None.
+
+    Raises
+    ------
+    ValueError
+        If lengths do not match, an explicit entry is not positive, an extent
+        keyword needs more axes than the array has, or a string is neither a
+        known keyword nor a parsable size.
+
+    Examples
+    --------
+    One shard per ZYX volume, rounded up to whole chunks:
+
+    >>> resolve_shards(
+    ...     "XYZ",
+    ...     shape=(5, 6, 86, 1664, 1193),
+    ...     chunks=(1, 1, 16, 256, 256),
+    ...     dtype="uint16",
+    ... )
+    (1, 1, 96, 1792, 1280)
+
+    A ~2 GB target on the same array, growing time only once the spatial axes
+    are full:
+
+    >>> resolve_shards(
+    ...     "2GB",
+    ...     shape=(5, 6, 86, 1664, 1193),
+    ...     chunks=(1, 1, 16, 256, 256),
+    ...     dtype="uint16",
+    ...     dimension_names=["t", "c", "z", "y", "x"],
+    ... )
+    (4, 1, 96, 1792, 1280)
+    """
+    if shards is None:
+        return None
+    if len(chunks) != len(shape):
+        raise ValueError(f"Chunk shape {tuple(chunks)} does not match shape length {len(shape)}.")
+    if any(c < 1 for c in chunks):
+        raise ValueError(f"Chunk shape {tuple(chunks)} must be positive along every axis.")
+
+    if not isinstance(shards, str):
+        try:
+            entries = tuple(int(s) for s in shards)
+        except TypeError as err:
+            raise TypeError(
+                f"shards must be a shard shape, a spatial extent, or a size string, "
+                f"got {type(shards).__name__}: {shards!r}."
+            ) from err
+        return _explicit_shards(entries, shape, chunks)
+
+    keyword = frozenset(shards.upper())
+    if keyword in _EXTENT_KEYWORDS:
+        return _extent_shards(_EXTENT_KEYWORDS[keyword], shards, shape, chunks)
+    try:
+        target_bytes = parse_shard_size(shards)
+    except ValueError as err:
+        raise ValueError(
+            f"Cannot interpret shards={shards!r}. Expected a shard shape, a spatial extent "
+            f"({' or '.join(sorted(''.join(sorted(k)) for k in _EXTENT_KEYWORDS))}), "
+            f"or a target size such as '2GB'."
+        ) from err
+    return _size_target_shards(target_bytes, shape, chunks, dtype, dimension_names)
+
+
+def resolve_shard_shape(
+    shards: ShardsLike,
+    shards_ratio: tuple[int, ...] | None,
+    *,
+    shape: tuple[int, ...],
+    chunks: tuple[int, ...],
+    dtype: DTypeLike,
+    dimension_names: Sequence[str] | None = None,
+    stacklevel: int = 3,
+) -> tuple[int, ...] | None:
+    """Resolve ``shards``, or the deprecated ``shards_ratio``, to a shard shape.
+
+    The array-creation API accepts both; this folds the legacy per-axis chunk
+    multiplier into the same result as ``shards`` and warns about it. Passing
+    both is an error, since they would each ask for a different geometry.
+
+    Parameters
+    ----------
+    shards : tuple[int, ...] or str or None
+        Shard intent, see :func:`resolve_shards`.
+    shards_ratio : tuple[int, ...], optional
+        Deprecated per-axis chunk multiplier (``shards = chunks * ratio``).
+    shape, chunks, dtype, dimension_names
+        See :func:`resolve_shards`.
+    stacklevel : int, optional
+        ``stacklevel`` for the deprecation warning, counted from this
+        function. Defaults to 3, which points at the caller of the public
+        array-creation method.
+
+    Returns
+    -------
+    tuple[int, ...] or None
+        Shard shape, or None when neither argument requests sharding.
+    """
+    if shards_ratio:
+        if shards is not None:
+            raise ValueError(
+                "Pass either shards or shards_ratio, not both. shards_ratio is deprecated; "
+                "prefer shards, which also accepts a size target like '2GB' or an extent like 'XYZ'."
+            )
+        warnings.warn(
+            "shards_ratio is deprecated and will be removed in a future release. Pass shards instead: "
+            "an explicit shard shape, a spatial extent ('XY' or 'XYZ'), or a size target like '2GB'.",
+            DeprecationWarning,
+            stacklevel=stacklevel,
+        )
+        if len(shards_ratio) != len(shape):
+            raise ValueError(f"Sharding ratio length {len(shards_ratio)} does not match shape length {len(shape)}.")
+        if len(chunks) != len(shape):
+            raise ValueError(f"Chunk shape {tuple(chunks)} does not match shape length {len(shape)}.")
+        shards = tuple(c * r for c, r in zip(chunks, shards_ratio, strict=True))
+    return resolve_shards(
+        shards,
+        shape=shape,
+        chunks=chunks,
+        dtype=dtype,
+        dimension_names=dimension_names,
+    )
+
+
+def _full_chunks_extent(shape: tuple[int, ...], chunks: tuple[int, ...]) -> tuple[int, ...]:
+    """Per-axis array size rounded up to a whole number of chunks.
+
+    This is the largest shard shape worth writing: anything beyond it only
+    pads the final shard of each axis with fill value.
+    """
+    return tuple(math.ceil(d / c) * c for d, c in zip(shape, chunks, strict=True))
+
+
+def _explicit_shards(
+    shards: tuple[int, ...],
+    shape: tuple[int, ...],
+    chunks: tuple[int, ...],
+) -> tuple[int, ...]:
+    """Round an explicit shard shape up to whole chunks.
+
+    An explicit shape is not capped at the array extent: a shard larger than
+    the array only leaves inner chunks unwritten, and silently shrinking what
+    the caller asked for would hide the mismatch.
+    """
+    if len(shards) != len(shape):
+        raise ValueError(f"Shard shape length {len(shards)} does not match shape length {len(shape)}.")
+    if any(s < 1 for s in shards):
+        raise ValueError(f"Shard shape {shards} must be positive along every axis.")
+    resolved = tuple(math.ceil(s / c) * c for s, c in zip(shards, chunks, strict=True))
+    if resolved != shards:
+        _logger.warning(f"Shard shape {shards} is not a whole number of {chunks} chunks; using {resolved}.")
+    return resolved
+
+
+def _extent_shards(
+    n_axes: int,
+    keyword: str,
+    shape: tuple[int, ...],
+    chunks: tuple[int, ...],
+) -> tuple[int, ...]:
+    """One shard per spatial extent: the trailing ``n_axes`` cover the array."""
+    if len(shape) < n_axes:
+        raise ValueError(f"shards={keyword!r} needs at least {n_axes} dimensions, but shape {shape} has {len(shape)}.")
+    extent = _full_chunks_extent(shape, chunks)
+    return tuple(chunks[:-n_axes]) + extent[-n_axes:]
+
+
+def _growth_order(
+    ndim: int,
+    dimension_names: Sequence[str] | None,
+) -> list[int]:
+    """Axis indices in the order a size target grows them.
+
+    Spatial axes come first, innermost (most contiguous on disk) first, so the
+    budget buys a contiguous region before it buys timepoints. Time axes come
+    last, and channel axes are left out entirely -- writers address single
+    channels, so a shard spanning channels cannot be written a channel at a
+    time.
+    """
+    if dimension_names is None:
+        names = list(_DEFAULT_AXIS_NAMES[-ndim:] if ndim <= len(_DEFAULT_AXIS_NAMES) else _DEFAULT_AXIS_NAMES)
+    else:
+        names = [str(n).lower() for n in dimension_names][:ndim]
+    # Unnamed leading axes are treated as spatial: growing them is wrong only
+    # if they are really channels, and a caller with channels has names.
+    names = [""] * (ndim - len(names)) + names
+    spatial, time = [], []
+    for axis in reversed(range(ndim)):
+        if names[axis] in _CHANNEL_NAMES:
+            continue
+        if names[axis] in _TIME_NAMES:
+            time.append(axis)
+        else:
+            spatial.append(axis)
+    return spatial + time
+
+
+def _size_target_shards(
+    target_bytes: int,
+    shape: tuple[int, ...],
+    chunks: tuple[int, ...],
+    dtype: DTypeLike,
+    dimension_names: Sequence[str] | None,
+) -> tuple[int, ...]:
+    """Largest chunk-aligned shard whose nominal size fits the byte target."""
+    itemsize = np.dtype(dtype).itemsize
+    extent = _full_chunks_extent(shape, chunks)
+    chunk_counts = tuple(e // c for e, c in zip(extent, chunks, strict=True))
+
+    shards = list(chunks)
+    nbytes = math.prod(chunks) * itemsize
+    if nbytes > target_bytes:
+        _logger.warning(
+            f"A single {chunks} chunk of {dtype} is {nbytes} bytes, over the {target_bytes} byte shard target; "
+            f"using one chunk per shard. Pass smaller chunks for smaller shards."
+        )
+        return tuple(shards)
+
+    # Growth is greedy, and greedy is exact here: an axis is only partially
+    # filled once the remaining budget is under one more multiple of it, and
+    # every later axis is at least that large.
+    for axis in _growth_order(len(shape), dimension_names):
+        multiple = min(chunk_counts[axis], target_bytes // nbytes)
+        if multiple <= 1:
+            continue
+        shards[axis] = chunks[axis] * multiple
+        nbytes *= multiple
+    return tuple(shards)

--- a/src/iohub/ngff/nodes.py
+++ b/src/iohub/ngff/nodes.py
@@ -32,6 +32,7 @@ from iohub.core.config import ImplementationConfig
 from iohub.core.errors import StoreOpenError
 from iohub.core.ozx import OzxStore, is_ozx_path, read_ozx_version
 from iohub.core.protocol import ZarrImplementation
+from iohub.core.sharding import ShardsLike, resolve_shard_shape
 from iohub.core.types import StorePath
 from iohub.core.utils import normalize_path, pad_shape
 from iohub.ngff._write_units import plan_write_unit
@@ -425,28 +426,35 @@ class NGFFNode:
         shape: tuple[int, ...],
         dtype,
         chunks: tuple[int, ...],
-        shards_ratio: tuple[int, ...] | None,
+        shards: ShardsLike = None,
+        shards_ratio: tuple[int, ...] | None = None,
         dimension_names: list[str] | None = None,
     ):
         """Create a zarr array via the active implementation and return the native handle."""
-        if shards_ratio:
-            if len(shards_ratio) != len(shape):
-                raise ValueError(f"Sharding ratio length {len(shards_ratio)} does not match shape length {len(shape)}.")
-            shards = tuple(c * s for c, s in zip(chunks, shards_ratio, strict=False))
-        else:
-            shards = None
-        if shards is not None and self._zarr_format == 2:
+        dimension_names = dimension_names or [ax.name for ax in self.axes[: len(shape)]]
+        shard_shape = resolve_shard_shape(
+            shards,
+            shards_ratio,
+            shape=shape,
+            chunks=chunks,
+            dtype=dtype,
+            dimension_names=dimension_names,
+            # Point the deprecation at the caller of create_zeros rather than
+            # at this internal hop.
+            stacklevel=4,
+        )
+        if shard_shape is not None and self._zarr_format == 2:
             raise ValueError(
-                "Sharding is not supported in Zarr v2 (OME-Zarr v0.4). Remove shards_ratio or use version='0.5'."
+                "Sharding is not supported in Zarr v2 (OME-Zarr v0.4). Remove shards or use version='0.5'."
             )
         if self._zarr_format == 3:
             spec = ArraySpec.create(
                 shape=shape,
                 dtype=dtype,
                 chunks=chunks,
-                shards=shards,
+                shards=shard_shape,
                 fill_value=0,
-                dimension_names=dimension_names or [ax.name for ax in self.axes[: len(shape)]],
+                dimension_names=dimension_names,
             )
             return self._impl.create_array(self._group, name, spec, overwrite=self._overwrite)
         return self._impl.create_array_v2(
@@ -754,6 +762,7 @@ class PositionLabel(NGFFNode):
         level: str,
         data: NDArray,
         chunks: tuple[int, ...] | None = None,
+        shards: ShardsLike = None,
         shards_ratio: tuple[int, ...] | None = None,
         transform: list[TransformationMeta] | None = None,
     ) -> LabelsArray:
@@ -770,8 +779,11 @@ class PositionLabel(NGFFNode):
             Label data (integer array, TZYX format)
         chunks : tuple[int, ...], optional
             Chunk size, by default None
+        shards : tuple[int, ...] or str, optional
+            Shard geometry, by default None (no sharding). See
+            :meth:`Position.create_zeros` for the accepted forms.
         shards_ratio : tuple[int, ...], optional
-            Sharding ratio for each dimension, by default None.
+            Deprecated per-axis multiplier over ``chunks``. Use ``shards``.
         transform : list[TransformationMeta], optional
             Coordinate transformations for this level, by default None
 
@@ -790,6 +802,7 @@ class PositionLabel(NGFFNode):
             shape=data.shape,
             dtype=data.dtype,
             chunks=chunks,
+            shards=shards,
             shards_ratio=shards_ratio,
             transform=transform,
         )
@@ -802,6 +815,7 @@ class PositionLabel(NGFFNode):
         shape: tuple[int, ...],
         dtype: DTypeLike,
         chunks: tuple[int, ...] | None = None,
+        shards: ShardsLike = None,
         shards_ratio: tuple[int, ...] | None = None,
         transform: list[TransformationMeta] | None = None,
     ) -> LabelsArray:
@@ -817,8 +831,11 @@ class PositionLabel(NGFFNode):
             Integer data type for labels
         chunks : tuple[int, ...], optional
             Chunk size, by default None
+        shards : tuple[int, ...] or str, optional
+            Shard geometry, by default None (no sharding). See
+            :meth:`Position.create_zeros` for the accepted forms.
         shards_ratio : tuple[int, ...], optional
-            Sharding ratio for each dimension, by default None.
+            Deprecated per-axis multiplier over ``chunks``. Use ``shards``.
         transform : list[TransformationMeta], optional
             Coordinate transformations, by default None
 
@@ -831,7 +848,7 @@ class PositionLabel(NGFFNode):
             raise ValueError(f"Labels must use integer dtype, got {dtype}")
         if not chunks:
             chunks = pad_shape(shape[-3:], target=len(shape))
-        arr_handle = self._create_zarr_array(level, shape, dtype, chunks, shards_ratio)
+        arr_handle = self._create_zarr_array(level, shape, dtype, chunks, shards, shards_ratio)
         lbl_arr = LabelsArray.from_handle(arr_handle, self._impl)
         self._create_label_meta(level, transform=transform)
         return lbl_arr
@@ -1105,6 +1122,7 @@ class Position(NGFFNode):
         name: str,
         data: NDArray,
         chunks: tuple[int, ...] | None = None,
+        shards: ShardsLike = None,
         shards_ratio: tuple[int, ...] | None = None,
         transform: list[TransformationMeta] | None = None,
         check_shape: bool = True,
@@ -1120,10 +1138,11 @@ class Position(NGFFNode):
         chunks : tuple[int, ...], optional
             Chunk size, by default None.
             ZYX stack size will be used if not specified.
+        shards : tuple[int, ...] or str, optional
+            Shard geometry, by default None (no sharding). See
+            :meth:`create_zeros` for the accepted forms.
         shards_ratio : tuple[int, ...], optional
-            Sharding ratio for each dimension, by default None.
-            Each shard contains the product of the ratios number of chunks.
-            No sharding will be used if not specified.
+            Deprecated per-axis multiplier over ``chunks``. Use ``shards``.
         transform : list[TransformationMeta], optional
             List of coordinate transformations, by default None.
             Should be specified for a non-native resolution level.
@@ -1141,6 +1160,7 @@ class Position(NGFFNode):
             shape=data.shape,
             dtype=data.dtype,
             chunks=chunks,
+            shards=shards,
             shards_ratio=shards_ratio,
             transform=transform,
             check_shape=check_shape,
@@ -1154,6 +1174,7 @@ class Position(NGFFNode):
         shape: tuple[int, ...],
         dtype: DTypeLike,
         chunks: tuple[int, ...] | None = None,
+        shards: ShardsLike = None,
         shards_ratio: tuple[int, ...] | None = None,
         transform: list[TransformationMeta] | None = None,
         check_shape: bool = True,
@@ -1177,10 +1198,24 @@ class Position(NGFFNode):
         chunks : tuple[int, ...], optional
             Chunk size, by default None.
             ZYX stack size will be used if not specified.
+        shards : tuple[int, ...] or str, optional
+            Shard geometry, by default None (no sharding). Only supported for
+            OME-Zarr v0.5 (Zarr v3). One of:
+
+            - an explicit TCZYX shard shape in array elements, rounded up to
+              whole chunks (``shards=(2, 1, 96, 1792, 1280)``);
+            - a spatial extent, ``"XY"`` for one shard per plane or ``"XYZ"``
+              for one shard per volume;
+            - a target file size such as ``"2GB"`` or ``"512MiB"``: the
+              largest chunk-aligned shard whose nominal (uncompressed) size
+              fits under the target. X grows first, then Y, then Z, then time,
+              so a torn shard costs a spatial region before it costs
+              timepoints. The channel axis is never grown, because writers
+              address single channels.
         shards_ratio : tuple[int, ...], optional
-            Sharding ratio for each dimension, by default None.
-            Each shard contains the product of the ratios number of chunks.
-            No sharding will be used if not specified.
+            Deprecated per-axis multiplier over ``chunks``
+            (``shards = chunks * shards_ratio``), by default None.
+            Use ``shards`` instead; passing both raises ``ValueError``.
         transform : list[TransformationMeta], optional
             List of coordinate transformations, by default None.
             Should be specified for a non-native resolution level.
@@ -1198,7 +1233,7 @@ class Position(NGFFNode):
 
         if check_shape:
             self._check_shape(shape)
-        arr_handle = self._create_zarr_array(name, shape, dtype, chunks, shards_ratio)
+        arr_handle = self._create_zarr_array(name, shape, dtype, chunks, shards, shards_ratio)
         img_arr = ImageArray.from_handle(arr_handle, self._impl)
         self._create_image_meta(name, transform=transform)
         return img_arr
@@ -1399,11 +1434,13 @@ class Position(NGFFNode):
             shape = _scale_dims(prev_shape, axes)
             chunks = _scale_dims(prev_chunks, axes)
 
+            # Downscaling shards and chunks separately can leave the shard off
+            # the chunk grid; create_zeros rounds it back up to whole chunks.
             if prev_shards is not None:
                 prev_shards = _scale_dims(prev_shards, axes)
-                shards_ratio = tuple(s // c for c, s in zip(chunks, prev_shards, strict=False))
+                shards = prev_shards
             else:
-                shards_ratio = None
+                shards = None
 
             transforms = deepcopy(self.metadata.multiscales[0].datasets[0].coordinate_transformations)
             for tr in transforms:
@@ -1420,7 +1457,7 @@ class Position(NGFFNode):
                 shape=shape,
                 dtype=self.data.dtype,
                 chunks=chunks,
-                shards_ratio=shards_ratio,
+                shards=shards,
                 transform=transforms,
             )
 
@@ -1837,6 +1874,7 @@ class Position(NGFFNode):
         colors: dict[int, list[int]] | None = None,
         properties: list[dict[str, Any]] | None = None,
         chunks: tuple[int, ...] | None = None,
+        shards: ShardsLike = None,
         shards_ratio: tuple[int, ...] | None = None,
         pyramid_levels: int = 1,
     ) -> PositionLabel:
@@ -1857,10 +1895,11 @@ class Position(NGFFNode):
             Properties for each label value, must include "label-value" field
         chunks : tuple[int, ...], optional
             Chunk size for the zarr arrays
+        shards : tuple[int, ...] or str, optional
+            Shard geometry, by default None (no sharding). See
+            :meth:`create_zeros` for the accepted forms.
         shards_ratio : tuple[int, ...], optional
-            Sharding ratio for each dimension, by default None.
-            Each shard contains the product of the ratios number of chunks.
-            No sharding will be used if not specified.
+            Deprecated per-axis multiplier over ``chunks``. Use ``shards``.
         pyramid_levels : int, optional
             Number of pyramid levels to create, by default 1
 
@@ -1960,7 +1999,7 @@ class Position(NGFFNode):
             impl=self._impl,
         )
 
-        label_image.create_label("0", data, chunks=chunks, shards_ratio=shards_ratio)
+        label_image.create_label("0", data, chunks=chunks, shards=shards, shards_ratio=shards_ratio)
 
         if pyramid_levels > 1:
             label_image.initialize_pyramid(pyramid_levels)

--- a/src/iohub/ngff/utils.py
+++ b/src/iohub/ngff/utils.py
@@ -18,6 +18,7 @@ import numpy as np
 from numpy.typing import DTypeLike, NDArray
 
 from iohub.core.compat import V04_MAX_CHUNK_SIZE_BYTES
+from iohub.core.sharding import ShardsLike
 from iohub.ngff import open_ome_zarr
 from iohub.ngff._write_units import (
     WriteUnit,
@@ -68,6 +69,7 @@ def create_empty_plate(
     channel_names: list[str],
     shape: tuple[int, ...],
     chunks: tuple[int, ...] | None = None,
+    shards: ShardsLike = None,
     shards_ratio: tuple[int, ...] | None = None,
     version: Literal["0.4", "0.5"] = "0.5",
     scale: tuple[float, ...] = (1, 1, 1, 1, 1),
@@ -99,12 +101,32 @@ def create_empty_plate(
         - "0.4": ``(1, 1, Z, Y, X)`` capped in Z to 500 MB.
         - "0.5": ``(1, 1, 16, 256, 256)`` clamped to ``shape``.
         Defaults to None.
-    shards_ratio : tuple[int, ...], optional
-        TCZYX shards ratio of the plate (shard size = chunks * shards_ratio).
+    shards : tuple[int, ...] or str, optional
+        Shard geometry of the plate. One of:
+
+        - an explicit TCZYX shard shape in array elements, rounded up to whole
+          chunks;
+        - a spatial extent, ``"XY"`` for one shard per plane or ``"XYZ"`` for
+          one shard per ZYX volume;
+        - a target file size such as ``"2GB"`` or ``"512MiB"``, which iohub
+          converts to the largest chunk-aligned shard that fits under it. X
+          grows first, then Y, then Z, then T, so a torn shard costs a spatial
+          region before it costs timepoints, and the channel axis is never
+          grown (channel-sharded stores cannot be written a channel at a
+          time). The target is compared against the nominal (uncompressed)
+          size, so compressed shards land under it.
+
         If None, a version-specific default is used:
+
         - "0.4": no sharding (Zarr v2 does not support it).
-        - "0.5": ratio that yields a shard size of ``(1, 1, Z, Y, X)``.
+        - "0.5": ``"XYZ"``, one shard per ZYX volume.
+
         Defaults to None.
+    shards_ratio : tuple[int, ...], optional
+        Deprecated TCZYX multiplier over ``chunks``
+        (``shards = chunks * shards_ratio``). Use ``shards`` instead, which
+        does not require knowing the chunk shape; passing both raises
+        ``ValueError``. Defaults to None.
     version : Literal["0.4", "0.5"], optional
         OME-Zarr version to use for the plate.
         Defaults to "0.5".
@@ -162,15 +184,26 @@ def create_empty_plate(
     ...     scale=(1, 1, 0.5, 0.5, 0.5),
     ... )
 
-    Create a plate with sharding:
+    Create a plate whose shards hold as much as fits in ~2 GB files:
+    >>> create_empty_plate(
+    ...     store_path=Path("/path/to/store"),
+    ...     position_keys=[("A", "1", "0")],
+    ...     channel_names=["DAPI"],
+    ...     shape=(100, 1, 64, 2048, 2048),
+    ...     chunks=(1, 1, 8, 128, 128),
+    ...     scale=(1, 1, 0.5, 0.5, 0.5),
+    ...     shards="2GB",
+    ...     version="0.5",
+    ... )
+
+    Create a plate with one shard per ZYX volume:
     >>> create_empty_plate(
     ...     store_path=Path("/path/to/store"),
     ...     position_keys=[("A", "1", "0")],
     ...     channel_names=["DAPI"],
     ...     shape=(1, 1, 64, 2048, 2048),
     ...     chunks=(1, 1, 8, 128, 128),
-    ...     scale=(1, 1, 0.5, 0.5, 0.5),
-    ...     shards_ratio=(10, 1, 8, 16, 16),
+    ...     shards="XYZ",
     ...     version="0.5",
     ... )
 
@@ -203,8 +236,8 @@ def create_empty_plate(
     if chunks is None:
         chunks = _default_chunks(shape, dtype, version)
 
-    if shards_ratio is None and version == "0.5":
-        shards_ratio = _default_shards_ratio(shape, chunks)
+    if shards is None and shards_ratio is None and version == "0.5":
+        shards = "XYZ"
 
     # Normalize to a list of Paths. Fail loudly if any metadata source root
     # is wrong; missing individual positions within them are still skipped
@@ -243,6 +276,7 @@ def create_empty_plate(
                 name="0",
                 shape=shape,
                 chunks=chunks,
+                shards=shards,
                 shards_ratio=shards_ratio,
                 dtype=dtype,
                 transform=[TransformationMeta(type="scale", scale=scale)],
@@ -773,14 +807,3 @@ def _default_chunks(
         return (1, 1, *chunk_zyx_shape)
     # v0.5: DCA-aligned small chunks, clamped to the array shape.
     return _clamp_chunks_to_shape(shape, (1, 1, *_V05_DEFAULT_ZYX_CHUNKS))
-
-
-def _default_shards_ratio(
-    shape: tuple[int, ...],
-    chunks: tuple[int, ...],
-) -> tuple[int, ...]:
-    """Shards ratio yielding a shard of (1, 1, Z, Y, X)."""
-    ratios = [1, 1]
-    for dim, chunk in zip(shape[-3:], chunks[-3:], strict=False):
-        ratios.append(-(-dim // chunk))
-    return tuple(ratios)

--- a/tests/core/test_sharding.py
+++ b/tests/core/test_sharding.py
@@ -1,0 +1,280 @@
+"""Unit tests for iohub.core.sharding (shard auto-sizing)."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from iohub.core.sharding import parse_shard_size, resolve_shard_shape, resolve_shards
+
+#: The mantis-v2 assemble output from issue #458: the shape whose shard
+#: geometry callers were computing by hand.
+_MANTIS_SHAPE = (5, 6, 86, 1664, 1193)
+_MANTIS_CHUNKS = (1, 1, 16, 256, 256)
+_TCZYX = ["t", "c", "z", "y", "x"]
+
+
+def _resolve(shards, shape=_MANTIS_SHAPE, chunks=_MANTIS_CHUNKS, dtype=np.uint16, names=_TCZYX):
+    return resolve_shards(shards, shape=shape, chunks=chunks, dtype=dtype, dimension_names=names)
+
+
+# ---------------------------------------------------------------------------
+# Size string parsing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("target", "expected"),
+    [
+        ("1B", 1),
+        ("4096", 4096),
+        ("2KB", 2_000),
+        ("2KiB", 2_048),
+        ("512MB", 512_000_000),
+        ("512MiB", 536_870_912),
+        ("2GB", 2_000_000_000),
+        ("2GiB", 2_147_483_648),
+        ("1.5GB", 1_500_000_000),
+        ("1TB", 10**12),
+        ("  2 gb  ", 2_000_000_000),
+        ("2gIb", 2_147_483_648),
+    ],
+)
+def test_parse_shard_size(target, expected):
+    assert parse_shard_size(target) == expected
+
+
+@pytest.mark.parametrize("target", ["", "GB", "2 gigabytes", "-2GB", "2PB", "1e9", "0.4B", "2GB2"])
+def test_parse_shard_size_rejects_garbage(target):
+    with pytest.raises(ValueError, match=r"Cannot parse shard size|cannot hold a chunk"):
+        parse_shard_size(target)
+
+
+# ---------------------------------------------------------------------------
+# Spatial extent keywords
+# ---------------------------------------------------------------------------
+
+
+def test_extent_xyz_covers_the_volume_in_whole_chunks():
+    """The keyword reproduces the ratio callers were computing by hand:
+    ceil(86/16), ceil(1664/256), ceil(1193/256) chunks in Z, Y, X."""
+    assert _resolve("XYZ") == (1, 1, 96, 1792, 1280)
+
+
+def test_extent_xy_covers_one_plane_stack():
+    """Z stays at one chunk, so a shard is a chunk-thick YX slab."""
+    assert _resolve("XY") == (1, 1, 16, 1792, 1280)
+
+
+@pytest.mark.parametrize("keyword", ["XYZ", "xyz", "ZYX", "zyx", "xZy"])
+def test_extent_keywords_are_order_and_case_insensitive(keyword):
+    assert _resolve(keyword) == _resolve("XYZ")
+
+
+def test_extent_is_exact_when_chunks_divide_the_shape():
+    assert _resolve("XYZ", shape=(4, 2, 32, 512, 512), chunks=(1, 1, 16, 256, 256)) == (1, 1, 32, 512, 512)
+
+
+def test_extent_needs_enough_axes():
+    with pytest.raises(ValueError, match="needs at least 3 dimensions"):
+        _resolve("XYZ", shape=(64, 64), chunks=(16, 16), names=["y", "x"])
+
+
+def test_extent_keeps_channel_at_one_chunk():
+    """C is never grown, even when its chunk size is 1 and the array has many."""
+    assert _resolve("XYZ")[1] == 1
+
+
+# ---------------------------------------------------------------------------
+# Size targets
+# ---------------------------------------------------------------------------
+
+
+def _nbytes(shards, dtype=np.uint16):
+    return math.prod(shards) * np.dtype(dtype).itemsize
+
+
+def test_size_target_fills_space_then_time():
+    """A 2 GB target buys the whole volume (440 MB) plus 3 more timepoints."""
+    shards = _resolve("2GB")
+    assert shards == (4, 1, 96, 1792, 1280)
+    assert _nbytes(shards) <= 2_000_000_000
+
+
+def test_size_target_stops_at_the_volume_when_time_does_not_fit():
+    """512 MiB holds one 440 MB volume; a second timepoint would overshoot."""
+    assert _resolve("512MiB") == (1, 1, 96, 1792, 1280)
+
+
+def test_size_target_below_one_volume_grows_only_x_and_y():
+    """A target under one volume fills X, then as much of Y as fits, and
+    leaves Z at one chunk."""
+    shards = _resolve("64MB")
+    assert shards == (1, 1, 16, 1536, 1280)  # 6 of the 7 Y chunks
+    assert _nbytes(shards) <= 64_000_000
+
+
+def test_size_target_partially_fills_the_innermost_axis():
+    """When not even a full X row fits, X grows to the multiple that does."""
+    shards = _resolve("8MB")
+    assert shards == (1, 1, 16, 256, 768)  # 3 of the 5 X chunks
+    assert _nbytes(shards) <= 8_000_000
+
+
+@pytest.mark.parametrize("target", ["4MB", "64MB", "512MB", "2GB", "1TB"])
+def test_size_target_is_never_exceeded_and_is_chunk_aligned(target):
+    shards = _resolve(target)
+    assert _nbytes(shards) <= parse_shard_size(target)
+    assert all(s % c == 0 for s, c in zip(shards, _MANTIS_CHUNKS, strict=True))
+    assert all(s <= math.ceil(d / c) * c for s, d, c in zip(shards, _MANTIS_SHAPE, _MANTIS_CHUNKS, strict=True))
+
+
+def test_size_target_never_grows_channels():
+    """Channels are unshardable, so the budget is spent on other axes."""
+    assert _resolve("1TB")[1] == 1
+
+
+def test_size_target_larger_than_the_array_covers_it_whole():
+    shards = _resolve("1TB")
+    assert shards == (5, 1, 96, 1792, 1280)
+
+
+def test_size_target_smaller_than_a_chunk_falls_back_to_one_chunk(caplog):
+    with caplog.at_level("WARNING", logger="iohub.core.sharding"):
+        shards = _resolve("1KB")
+    assert shards == _MANTIS_CHUNKS
+    assert "over the" in caplog.text
+
+
+def test_size_target_accounts_for_dtype():
+    """The same target buys half as many float32 elements as uint16 ones."""
+    small = _resolve("2GB", dtype=np.float32)
+    large = _resolve("2GB", dtype=np.uint16)
+    assert small[0] * 2 == large[0]
+
+
+def test_size_target_without_names_assumes_tczyx():
+    """A 5D array without names is read as TCZYX, so C is still protected."""
+    assert _resolve("2GB", names=None) == _resolve("2GB")
+
+
+def test_size_target_on_a_named_tzyx_array_grows_time_last():
+    """Label arrays are TZYX: axis 1 is Z, and only the named T grows last."""
+    shards = resolve_shards(
+        "2GB",
+        shape=(5, 86, 1664, 1193),
+        chunks=(1, 16, 256, 256),
+        dtype=np.uint16,
+        dimension_names=["t", "z", "y", "x"],
+    )
+    assert shards == (4, 96, 1792, 1280)
+
+
+# ---------------------------------------------------------------------------
+# Explicit shard shapes
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_shape_passes_through():
+    assert _resolve((2, 1, 96, 1792, 1280)) == (2, 1, 96, 1792, 1280)
+
+
+def test_explicit_shape_rounds_up_to_whole_chunks(caplog):
+    with caplog.at_level("WARNING", logger="iohub.core.sharding"):
+        shards = _resolve((1, 1, 20, 300, 300))
+    assert shards == (1, 1, 32, 512, 512)
+    assert "whole number of" in caplog.text
+
+
+def test_explicit_shape_may_exceed_the_array():
+    """An explicit shape is taken as given; the trailing shard is just padded."""
+    assert _resolve((16, 1, 96, 1792, 1280))[0] == 16
+
+
+def test_explicit_shape_length_must_match():
+    with pytest.raises(ValueError, match="Shard shape length 3 does not match shape length 5"):
+        _resolve((1, 1, 16))
+
+
+@pytest.mark.parametrize("shards", [(1, 1, 0, 256, 256), (1, 1, -16, 256, 256)])
+def test_explicit_shape_must_be_positive(shards):
+    with pytest.raises(ValueError, match="must be positive"):
+        _resolve(shards)
+
+
+# ---------------------------------------------------------------------------
+# Argument handling
+# ---------------------------------------------------------------------------
+
+
+def test_none_means_no_sharding():
+    assert _resolve(None) is None
+
+
+def test_unknown_string_lists_the_accepted_forms():
+    with pytest.raises(ValueError, match="Cannot interpret shards='volume'"):
+        _resolve("volume")
+
+
+def test_chunk_length_must_match_shape():
+    with pytest.raises(ValueError, match="does not match shape length"):
+        _resolve("XYZ", chunks=(1, 1, 16))
+
+
+def test_lists_are_accepted_as_shard_shapes():
+    assert _resolve([1, 1, 96, 1792, 1280]) == (1, 1, 96, 1792, 1280)
+
+
+def test_a_bare_number_is_rejected():
+    """An int is neither a shape nor a size target; say so instead of failing
+    on iteration."""
+    with pytest.raises(TypeError, match="got int"):
+        _resolve(2_000_000_000)
+
+
+# ---------------------------------------------------------------------------
+# Deprecated shards_ratio
+# ---------------------------------------------------------------------------
+
+
+def _resolve_both(shards, shards_ratio):
+    return resolve_shard_shape(
+        shards,
+        shards_ratio,
+        shape=_MANTIS_SHAPE,
+        chunks=_MANTIS_CHUNKS,
+        dtype=np.uint16,
+        dimension_names=_TCZYX,
+    )
+
+
+def test_shards_ratio_still_multiplies_chunks():
+    with pytest.deprecated_call(match="shards_ratio is deprecated"):
+        assert _resolve_both(None, (1, 1, 6, 7, 5)) == (1, 1, 96, 1792, 1280)
+
+
+def test_shards_ratio_may_exceed_the_array():
+    """The legacy form is unclamped, so existing geometries are preserved."""
+    with pytest.deprecated_call():
+        assert _resolve_both(None, (10, 1, 8, 8, 8)) == (10, 1, 128, 2048, 2048)
+
+
+def test_shards_and_shards_ratio_conflict():
+    with pytest.raises(ValueError, match="not both"):
+        _resolve_both("2GB", (1, 1, 6, 7, 5))
+
+
+def test_shards_ratio_length_must_match():
+    with pytest.deprecated_call(), pytest.raises(ValueError, match="Sharding ratio length"):
+        _resolve_both(None, (1, 1, 6))
+
+
+def test_neither_argument_means_no_sharding():
+    assert _resolve_both(None, None) is None
+
+
+def test_empty_shards_ratio_is_ignored():
+    """The legacy falsy-ratio path means "no sharding", without a warning."""
+    assert _resolve_both(None, ()) is None

--- a/tests/ngff/test_ngff.py
+++ b/tests/ngff/test_ngff.py
@@ -2052,8 +2052,107 @@ def test_sharding_raises_on_v04(tmp_path):
             ds.create_image(
                 "0",
                 np.zeros((1, 1, 1, 64, 64)),
-                shards_ratio=(1, 1, 1, 2, 2),
+                shards="XYZ",
             )
+
+
+# --- Shard auto-sizing (issue #458) -----------------------------------------
+
+
+@contextmanager
+def _sharded_fov(tmp_path, shape, chunks, shards, dtype=np.uint16):
+    """A v0.5 FOV with a single zero-filled array, created with ``shards``."""
+    with open_ome_zarr(
+        tmp_path / "shards.zarr",
+        layout="fov",
+        mode="w-",
+        channel_names=[f"c{i}" for i in range(shape[1])],
+        version="0.5",
+    ) as dataset:
+        dataset.create_zeros("0", shape=shape, dtype=dtype, chunks=chunks, shards=shards)
+        yield dataset
+
+
+def test_create_zeros_with_size_target(tmp_path):
+    """A size target is resolved against the chunk shape the caller passed."""
+    with _sharded_fov(
+        tmp_path,
+        shape=(8, 2, 32, 512, 512),
+        chunks=(1, 1, 16, 256, 256),
+        shards="20MB",
+    ) as dataset:
+        # One chunk is 2 MiB, so 8 of them fit: 2 in X, 2 in Y, 2 in Z, and
+        # nothing left for T.
+        assert dataset["0"].shards == (1, 1, 32, 512, 512)
+
+
+def test_create_zeros_with_extent_keyword(tmp_path):
+    """``"XY"`` shards a chunk-thick YX slab, ``"XYZ"`` a whole volume."""
+    shape, chunks = (2, 2, 32, 512, 512), (1, 1, 16, 256, 256)
+    with _sharded_fov(tmp_path / "xy", shape, chunks, "XY") as dataset:
+        assert dataset["0"].shards == (1, 1, 16, 512, 512)
+    with _sharded_fov(tmp_path / "xyz", shape, chunks, "XYZ") as dataset:
+        assert dataset["0"].shards == (1, 1, 32, 512, 512)
+
+
+def test_create_zeros_shards_round_up_to_whole_chunks(tmp_path):
+    """An explicit shard shape off the chunk grid is rounded up, not rejected."""
+    with _sharded_fov(
+        tmp_path,
+        shape=(2, 1, 32, 512, 512),
+        chunks=(1, 1, 16, 256, 256),
+        shards=(1, 1, 20, 300, 300),
+    ) as dataset:
+        assert dataset["0"].shards == (1, 1, 32, 512, 512)
+
+
+def test_create_zeros_rejects_shards_with_shards_ratio(tmp_path):
+    with pytest.raises(ValueError, match="not both"):
+        with _sharded_fov(tmp_path, (2, 1, 8, 64, 64), (1, 1, 8, 64, 64), "XYZ") as dataset:
+            dataset.create_zeros(
+                "1",
+                shape=(2, 1, 8, 64, 64),
+                dtype=np.uint16,
+                shards="XYZ",
+                shards_ratio=(2, 1, 1, 1, 1),
+            )
+
+
+def test_create_zeros_shards_ratio_warns(tmp_path):
+    """The legacy multiplier keeps working, with a deprecation warning."""
+    with (
+        open_ome_zarr(
+            tmp_path / "ratio.zarr",
+            layout="fov",
+            mode="w-",
+            channel_names=["c0"],
+            version="0.5",
+        ) as dataset,
+        pytest.deprecated_call(match="shards_ratio is deprecated"),
+    ):
+        arr = dataset.create_zeros(
+            "0",
+            shape=(4, 1, 32, 512, 512),
+            dtype=np.uint16,
+            chunks=(1, 1, 16, 256, 256),
+            shards_ratio=(2, 1, 2, 2, 2),
+        )
+        assert arr.shards == (2, 1, 32, 512, 512)
+
+
+def test_sharded_pyramid_levels_stay_chunk_aligned(tmp_path):
+    """Downscaled levels keep a valid shard geometry, even off the grid."""
+    with _sharded_fov(
+        tmp_path,
+        shape=(2, 1, 24, 96, 96),
+        chunks=(1, 1, 3, 6, 6),
+        shards="XYZ",
+    ) as dataset:
+        dataset.initialize_pyramid(levels=3)
+        for level in ("0", "1", "2"):
+            arr = dataset[level]
+            assert all(s % c == 0 for s, c in zip(arr.shards, arr.chunks, strict=True))
+            assert all(s >= 1 for s in arr.shards)
 
 
 def _make_bf2raw_fixture(

--- a/tests/ngff/test_ngff_utils.py
+++ b/tests/ngff/test_ngff_utils.py
@@ -1,5 +1,6 @@
 import itertools
 import json
+import math
 import os
 import shutil
 import string
@@ -1363,18 +1364,89 @@ def test_v05_explicit_shards_ratio_is_honored(tmp_path):
     """An explicit shards_ratio overrides the default."""
     shape = (4, 2, 16, 256, 256)
     store = tmp_path / "test.zarr"
-    create_empty_plate(
-        store_path=store,
-        position_keys=[("A", "1", "0")],
-        channel_names=[f"c{i}" for i in range(shape[1])],
-        shape=shape,
-        chunks=(1, 1, 16, 256, 256),
-        shards_ratio=(2, 2, 1, 1, 1),
-        version="0.5",
-    )
+    with pytest.deprecated_call(match="shards_ratio is deprecated"):
+        create_empty_plate(
+            store_path=store,
+            position_keys=[("A", "1", "0")],
+            channel_names=[f"c{i}" for i in range(shape[1])],
+            shape=shape,
+            chunks=(1, 1, 16, 256, 256),
+            shards_ratio=(2, 2, 1, 1, 1),
+            version="0.5",
+        )
     arr = _open_array(store, ("A", "1", "0"))
     assert arr.chunks == (1, 1, 16, 256, 256)
     assert arr.shards == (2, 2, 16, 256, 256)
+
+
+def test_v05_explicit_shard_shape_is_honored(tmp_path):
+    """An explicit TCZYX shard shape overrides the default."""
+    store = tmp_path / "test.zarr"
+    create_empty_plate(
+        store_path=store,
+        position_keys=[("A", "1", "0")],
+        channel_names=["c0", "c1"],
+        shape=(4, 2, 16, 256, 256),
+        chunks=(1, 1, 16, 256, 256),
+        shards=(2, 1, 16, 256, 256),
+        version="0.5",
+    )
+    arr = _open_array(store, ("A", "1", "0"))
+    assert arr.shards == (2, 1, 16, 256, 256)
+
+
+def test_v05_shard_size_target_fills_space_before_time(tmp_path):
+    """A byte target is met without the caller knowing the chunk shape.
+
+    The mantis-v2 case from issue #458: one (Z, Y, X) volume is ~440 MB, so a
+    2 GB target buys the volume plus three more timepoints.
+    """
+    store = tmp_path / "test.zarr"
+    create_empty_plate(
+        store_path=store,
+        position_keys=[("A", "1", "0")],
+        channel_names=[f"c{i}" for i in range(6)],
+        shape=(5, 6, 86, 1664, 1193),
+        shards="2GB",
+        dtype=np.uint16,
+        version="0.5",
+    )
+    arr = _open_array(store, ("A", "1", "0"))
+    assert arr.chunks == (1, 1, *_V05_DEFAULT_ZYX_CHUNKS)
+    assert arr.shards == (4, 1, 96, 1792, 1280)
+    assert math.prod(arr.shards) * 2 <= 2_000_000_000
+
+
+def test_v05_shard_extent_keyword_matches_the_default(tmp_path):
+    """``shards="XYZ"`` states the default explicitly."""
+    shape = (4, 2, 20, 300, 300)
+    stores = {}
+    for name, shards in (("default", None), ("explicit", "XYZ")):
+        store = tmp_path / f"{name}.zarr"
+        create_empty_plate(
+            store_path=store,
+            position_keys=[("A", "1", "0")],
+            channel_names=["c0", "c1"],
+            shape=shape,
+            shards=shards,
+            version="0.5",
+        )
+        stores[name] = _open_array(store, ("A", "1", "0")).shards
+    assert stores["default"] == stores["explicit"] == (1, 1, 32, 512, 512)
+
+
+def test_v05_shards_and_shards_ratio_conflict(tmp_path):
+    """Asking for both geometries is an error rather than a silent winner."""
+    with pytest.raises(ValueError, match="not both"):
+        create_empty_plate(
+            store_path=tmp_path / "test.zarr",
+            position_keys=[("A", "1", "0")],
+            channel_names=["c0"],
+            shape=(4, 1, 16, 256, 256),
+            shards="2GB",
+            shards_ratio=(2, 1, 1, 1, 1),
+            version="0.5",
+        )
 
 
 def test_v04_default_chunks_cover_full_zyx(tmp_path):
@@ -1434,13 +1506,28 @@ def test_v04_default_has_no_sharding(tmp_path):
 def test_v04_rejects_explicit_shards_ratio(tmp_path):
     """Passing shards_ratio on a v0.4 store raises (Zarr v2 has no sharding)."""
     store = tmp_path / "test.zarr"
-    with pytest.raises(ValueError, match="Sharding is not supported in Zarr v2"):
+    with pytest.deprecated_call(), pytest.raises(ValueError, match="Sharding is not supported in Zarr v2"):
         create_empty_plate(
             store_path=store,
             position_keys=[("A", "1", "0")],
             channel_names=["c0"],
             shape=(2, 1, 8, 64, 64),
             shards_ratio=(1, 1, 1, 1, 1),
+            version="0.4",
+        )
+
+
+@pytest.mark.parametrize("shards", ["2GB", "XYZ", (1, 1, 8, 64, 64)])
+def test_v04_rejects_shards(tmp_path, shards):
+    """Every shards form is rejected on a v0.4 store, not silently ignored."""
+    store = tmp_path / "test.zarr"
+    with pytest.raises(ValueError, match="Sharding is not supported in Zarr v2"):
+        create_empty_plate(
+            store_path=store,
+            position_keys=[("A", "1", "0")],
+            channel_names=["c0"],
+            shape=(2, 1, 8, 64, 64),
+            shards=shards,
             version="0.4",
         )
 


### PR DESCRIPTION
Closes #458.

## What

Adds a `shards` argument to iohub's array-creation API so callers state the shard *intent* and iohub derives a chunk-aligned geometry. It accepts three forms, following the way `TiffConverter` already accepts either explicit `chunks` or a keyword:

| Form | Meaning |
| --- | --- |
| `shards="2GB"`, `"512MiB"`, `"1.5GB"`, `"1048576"` | Largest chunk-aligned shard whose nominal (uncompressed) size stays under the target |
| `shards="XY"` / `shards="XYZ"` | One shard per plane / per ZYX volume (any letter order, case-insensitive) |
| `shards=(2, 1, 96, 1792, 1280)` | Explicit TCZYX shard shape in elements, rounded up to whole chunks |

Available on `create_empty_plate`, `Position.create_zeros` / `create_image` / `create_label`, and `PositionLabel.create_zeros` / `create_label`.

The mantis-v2 example from the issue — shape `[T, 6, 86, 1664, 1193]`, chunks `(1, 1, 16, 256, 256)`, uint16 — no longer needs the hand-computed `ceil()` arithmetic:

```python
create_empty_plate(..., shards="XYZ")  # -> shards (1, 1, 96, 1792, 1280)
create_empty_plate(..., shards="2GB")  # -> shards (4, 1, 96, 1792, 1280), 1.76 GB
```

## Constraints encoded in the sizer

- **C is never grown.** A channel-spanning shard cannot be written a channel at a time (`process_single_position` rejects it), so the channel axis stays at one chunk in every derived form. That footgun is no longer reachable without writing an explicit shape.
- **Spatial before time.** A byte target fills X, then Y, then Z, and only then spends budget on T, so blast radius grows last. Per the issue discussion T is allowed to grow freely once space is full, which is what makes ~2 GB targets reachable on small volumes.
- Growth is greedy and exact: once an axis is partially filled the remaining budget cannot fit a second multiple of any outer axis, so no better packing exists in this ordering.
- The target is compared against nominal (uncompressed) bytes, so compressed shards land under it. Documented rather than estimated.

## `shards_ratio`

Still works, now emits a `DeprecationWarning`; passing both `shards` and `shards_ratio` raises `ValueError`. The legacy path keeps its exact `chunks * ratio` semantics (uncapped), so existing geometries are byte-for-byte unchanged. `create_empty_plate`'s v0.5 default is unchanged, just spelled `shards="XYZ"` instead of a computed ratio.

Callers to update eventually: biahub's `ConcatenateSettings.shards_ratio` and the other per-position writers.

## Incidental fix

`initialize_pyramid` derived each level's ratio with floor division over downscaled shards and chunks, which could round a shard axis down to **zero** chunks (e.g. chunk 3 → 2, shard 3 → 1 → ratio 0) and write an invalid array. It now passes the downscaled shard shape and lets resolution round it back onto the chunk grid.

## Tests

- `tests/core/test_sharding.py` (new, 62 cases): size-string parsing incl. SI vs binary units and garbage; extent keywords, order/case insensitivity, rank guard; byte targets — never exceeded, chunk-aligned, within the array extent, dtype-scaled, C never grown, sub-chunk target falls back to one chunk with a warning; explicit shapes — round-up warning, may exceed the array, validation; deprecation and conflict handling.
- `tests/ngff/test_ngff.py`: `create_zeros` with each form, round-up on the real store, v0.4 rejection for all forms, deprecation warning, and sharded pyramid levels staying chunk-aligned.
- `tests/ngff/test_ngff_utils.py`: `create_empty_plate` with a size target (the issue's shape), `"XYZ"` matching the default, explicit shape, and the conflict error.

Full `tests/ngff tests/core tests/cli tests/fov` run is clean apart from 11 failures that also fail on `main` (missing local test data / fixtures), verified by re-running them on a stashed tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)