### PR TITLE
docs: updates docs UI to be easier to read

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@srivarra 
+@srivarra

--- a/docs/api/converter.md
+++ b/docs/api/converter.md
@@ -1,7 +1,19 @@
-# Convert TIFF to OME-Zarr
+# Convert to OME-Zarr
+
+Convert Micro-Manager TIFF formats and Nikon ND2 datasets to OME-Zarr.
 
 !!! note
     There is also a CLI command for conversion.
     See the [CLI Reference](../cli.md) or run `iohub convert --help`.
 
+## Supported inputs
+
+- Micro-Manager OME-TIFF
+- Micro-Manager NDTiff
+- Nikon ND2
+
+## Python
+
 ::: iohub.convert.TIFFConverter
+    options:
+      heading_level: 3

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -10,4 +10,8 @@
 
 ## Conversion
 
-- [Converter](converter.md) - TIFF to OME-Zarr conversion
+- [Conversion](converter.md) - TIFF and ND2 to OME-Zarr conversion
+
+## Utilities
+
+- [Utilities](utils.md) - Utility functions for creating and processing OME-Zarr data

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -1,0 +1,15 @@
+# Utilities
+
+## OME-Zarr data
+
+::: iohub.ngff.utils.create_empty_plate
+    options:
+      heading_level: 3
+
+::: iohub.ngff.utils.apply_transform_to_tczyx_and_save
+    options:
+      heading_level: 3
+
+::: iohub.ngff.utils.process_single_position
+    options:
+      heading_level: 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,10 +75,11 @@ acquire-zarr = [
     "acquire-zarr",
 ]
 doc = [
-    "zensical>=0.0.51",
-    "mkdocstrings-python>=2.0.5",
+    "zensical>=0.0.57",
+    "mkdocstrings-python>=2.0.8",
     "mkdocs-click>=0.9.0",
-    "pymdown-extensions>=11.0.0",
+    "pymdown-extensions>=11.0.2",
+    "ruff>=0.16.5",
     "mike",
 ]
 dev = [

--- a/src/iohub/convert.py
+++ b/src/iohub/convert.py
@@ -69,10 +69,10 @@ def _create_grid_from_coordinates(xy_coords: list[tuple[float, float]], rows: in
 
 
 class TIFFConverter:
-    """Convert Micro-Manager TIFF formats
+    """Convert supported microscopy datasets to OME-Zarr.
 
-    (OME-TIFF, ND-TIFF) into HCS OME-Zarr.
-    Each FOV will be written to a separate well in the plate layout.
+    Supports Micro-Manager TIFF formats (OME-TIFF and NDTiff) and Nikon ND2.
+    Each FOV is written to a separate well in the plate layout.
 
     Parameters
     ----------

--- a/src/iohub/core/arrays.py
+++ b/src/iohub/core/arrays.py
@@ -28,7 +28,7 @@ class _OIndexProxy:
 class NGFFArray:
     """Base class for NGFF N-dimensional arrays.
 
-    Delegates all I/O to the configured :class:`ZarrImplementation`.
+    Delegates all I/O to the configured `ZarrImplementation`.
     Subclassed by ``ImageArray`` (5D) and ``TiledImageArray`` in ``nodes.py``.
     """
 

--- a/src/iohub/core/implementations/__init__.py
+++ b/src/iohub/core/implementations/__init__.py
@@ -1,7 +1,7 @@
 """Zarr I/O implementation backends.
 
 Implementations are discovered via the ``iohub.zarr_implementations``
-entry point group. See :mod:`iohub.core.registry` for the discovery mechanism.
+entry point group. See `iohub.core.registry` for the discovery mechanism.
 
 For direct imports::
 

--- a/src/iohub/core/ozx.py
+++ b/src/iohub/core/ozx.py
@@ -149,14 +149,14 @@ def _write_ozx_comment(
 class OzxStore(ZipStore):
     """RFC-9 (Zipped OME-Zarr) store.
 
-    A :class:`zarr.storage.ZipStore` subclass with RFC-9 defaults:
+    A `zarr.storage.ZipStore` subclass with RFC-9 defaults:
     ``ZIP_STORED`` (Zarr codecs handle compression), ``allowZip64=True``
     (regardless of size), and the archive comment written on ``close()``.
 
     The store writes entries in zarr's creation order and leaves
     ``jsonFirst`` unset. For a SHOULD-compliant archive ready for
     HTTP-range publishing, write to a directory store first and run
-    :func:`pack_ozx`.
+    [`pack_ozx`][iohub.core.pack_ozx].
 
     Fork-safe: an ``os.register_at_fork`` hook invalidates the
     inherited ``ZipFile`` fd in child processes, so each child opens
@@ -336,7 +336,7 @@ def unpack_ozx(src: str | Path, dst: str | Path) -> Path:
 
     Walks the archive, dedupes shadow ``zarr.json`` entries (last-wins,
     matching ``ZipFile.read``), and writes each entry as a file under
-    ``dst``. Reverse of :func:`pack_ozx`.
+    ``dst``. Reverse of [`pack_ozx`][iohub.core.pack_ozx].
 
     Parameters
     ----------

--- a/src/iohub/core/protocol.py
+++ b/src/iohub/core/protocol.py
@@ -123,7 +123,7 @@ class ZarrImplementation[G, A](GroupBackend[G], ArrayBackend[G, A], ArrayIO[A], 
     """Combined Protocol satisfied by any full zarr I/O backend.
 
     A conforming class must implement all methods from
-    :class:`GroupBackend`, :class:`ArrayBackend`, and :class:`ArrayIO`.
+    `GroupBackend`, `ArrayBackend`, and `ArrayIO`.
     Specialise as ``ZarrImplementation[zarr.Group, zarr.Array]`` for
     static type-checker use.
     """

--- a/src/iohub/nd2.py
+++ b/src/iohub/nd2.py
@@ -50,7 +50,7 @@ class ND2FOV(MicroManagerFOV):
 
 
 class ND2Dataset(MicroManagerFOVMapping):
-    """Reader for Nikon ND2 datasets, wrapping :class:`nd2.ND2File`.
+    """Reader for Nikon ND2 datasets, wrapping `nd2.ND2File`.
 
     Each ND2 stage position (``P``) is exposed as a separate FOV. Files
     without a position axis are read as a single FOV. Data are returned in

--- a/src/iohub/ngff/_write_units.py
+++ b/src/iohub/ngff/_write_units.py
@@ -1,6 +1,6 @@
 """Tracking of shard-aligned write units so an interrupted run can resume.
 
-:func:`iohub.ngff.utils.process_single_position` splits its work into units of
+`iohub.ngff.utils.process_single_position` splits its work into units of
 one shard-aligned batch of timepoints for one channel group. Each unit owns a
 set of files on disk outright, which makes two things possible:
 
@@ -174,7 +174,7 @@ def tracking_available(array) -> bool:
     False for a store whose chunk key layout is not modelled here (Zarr v2,
     i.e. OME-Zarr v0.4), one not backed by a filesystem, or one reached
     through an implementation other than zarr-python. Says nothing about
-    whether a *particular* write owns its files; see :func:`plan_write_unit`
+    whether a *particular* write owns its files; see `plan_write_unit`
     for that.
     """
     return _array_directory(array) is not None and _chunk_key_encoding(array) is not None
@@ -197,7 +197,7 @@ def plan_write_unit(
     cover the full in-bounds extent of the files they land in.
 
     Assumes the write spans the entire ZYX extent of the array, which is what
-    :func:`iohub.ngff.utils.apply_transform_to_tczyx_and_save` does.
+    `iohub.ngff.utils.apply_transform_to_tczyx_and_save` does.
 
     ``token`` is mixed into the unit's identity. Pass a fingerprint of
     whatever determines the output — settings, input revision — so that a run
@@ -205,9 +205,9 @@ def plan_write_unit(
     and skip work that would now produce different data.
 
     ``progress_dir`` is where completion is recorded, normally from
-    :func:`progress_dir_for`. Omit it for repair without resume: the shard
+    `progress_dir_for`. Omit it for repair without resume: the shard
     paths are still computed, so a torn shard is still replaced, but nothing
-    is written outside the store. This is what :meth:`Position.write_xarray`
+    is written outside the store. This is what `Position.write_xarray`
     uses, since it has no notion of a resumable unit of work.
     """
     directory = _array_directory(array)

--- a/src/iohub/ngff/nodes.py
+++ b/src/iohub/ngff/nodes.py
@@ -294,7 +294,11 @@ class NGFFNode:
         raise NotImplementedError
 
     def __delitem__(self, key):
-        """.. Warning: this does NOT clean up metadata!"""
+        """Delete a child without cleaning up metadata.
+
+        !!! warning
+            This does **not** clean up metadata.
+        """
         key = normalize_path(str(key))
         del self._group[key]
 
@@ -759,7 +763,7 @@ class PositionLabel(NGFFNode):
     ) -> LabelsArray:
         """Create a label array at a specific resolution level.
 
-        Parallel to :meth:`Position.create_image` for creating label
+        Parallel to [`Position.create_image`][iohub.ngff.Position.create_image] for creating label
         arrays at specific multiscale resolution levels.
 
         Parameters
@@ -1030,10 +1034,10 @@ class Position(NGFFNode):
 
     @property
     def data(self):
-        """.. warning::
+        """!!! warning
 
             This property does *NOT* aim to retrieve all the arrays.
-            And it may also fail to retrive any data if arrays exist but
+            And it may also fail to retrieve any data if arrays exist but
             are not named conventionally.
 
         Alias for an array named '0' in the position,
@@ -1657,7 +1661,7 @@ class Position(NGFFNode):
             or "*" for the whole FOV
         transform : list[TransformationMeta]
             List of transformations to apply
-            (:py:class:`iohub.ngff_meta.TransformationMeta`)
+            (`TransformationMeta`)
         """
         if image == "*":
             self.metadata.multiscales[0].coordinate_transformations = transform
@@ -2159,7 +2163,7 @@ class Position(NGFFNode):
         arr = self[image]
         # Clear whole shards this write owns before writing them, so a shard
         # left truncated by a killed job is replaced rather than read back and
-        # rejected. See :mod:`iohub.ngff._write_units`.
+        # rejected. See `iohub.ngff._write_units`.
         unit = plan_write_unit(arr, [int(t) for t in t_indices], c_indices)
         if unit is not None:
             unit.clear()
@@ -2177,7 +2181,7 @@ class TiledPosition(Position):
 
     with convenience methods to create and access tiled arrays.
     Other parameters and attributes are the same as
-    :py:class:`iohub.ngff.Position`.
+    [`Position`][iohub.ngff.Position].
     """
 
     _MEMBER_TYPE = TiledImageArray
@@ -2435,8 +2439,9 @@ class Plate(NGFFNode):
 
         by copying images and metadata from a dictionary of positions.
 
-        .. warning: This assumes same channel names and axes across the FOVs
-            and does not check for consistent shape and chunk size.
+        !!! warning
+            This assumes the FOVs have the same channel names and axes, and
+            does not check for consistent shapes or chunk sizes.
 
         Parameters
         ----------
@@ -2444,7 +2449,7 @@ class Plate(NGFFNode):
             Path of the new store
         positions : dict[str, Position]
             Dictionary where keys are destination path names ('row/column/fov')
-            and values are :py:class:`iohub.ngff.Position` objects.
+            and values are [`Position`][iohub.ngff.Position] objects.
 
         Returns
         -------
@@ -2693,7 +2698,8 @@ class Plate(NGFFNode):
     def create_positions(self, positions: list[PositionSpec]) -> list[Position]:
         """Creates multiple position groups in the plate efficiently.
 
-        This is a vectorized version of :py:meth:`create_position` that creates
+        This is a vectorized version of
+        [`create_position`][iohub.ngff.Plate.create_position] that creates
         multiple positions in a single call. Wells are created as needed and
         metadata is written in batches for better performance.
 
@@ -3031,7 +3037,8 @@ class Bioformats2RawSeries(NGFFNode):
     def positions(self) -> Generator[tuple[str, Position]]:
         """Iterate over ``(name, Position)`` pairs of all series.
 
-        Matches :py:meth:`Plate.positions` and :py:meth:`Well.positions` so
+        Matches [`Plate.positions`][iohub.ngff.Plate.positions] and
+        `Well.positions` so
         downstream code can iterate any FOV-bearing node uniformly.
         """
         yield from self.iteritems()
@@ -3240,13 +3247,13 @@ def open_ome_zarr(
     axes : list[AxisMeta], optional
         OME axes metadata, by default None:
 
-        .. code-block:: text
-
-            [AxisMeta(name='T', type='time', unit='second'),
-            AxisMeta(name='C', type='channel', unit=None),
-            AxisMeta(name='Z', type='space', unit='micrometer'),
-            AxisMeta(name='Y', type='space', unit='micrometer'),
-            AxisMeta(name='X', type='space', unit='micrometer')]
+        ```text
+        [AxisMeta(name='T', type='time', unit='second'),
+         AxisMeta(name='C', type='channel', unit=None),
+         AxisMeta(name='Z', type='space', unit='micrometer'),
+         AxisMeta(name='Y', type='space', unit='micrometer'),
+         AxisMeta(name='X', type='space', unit='micrometer')]
+        ```
 
     version : Literal["0.4", "0.5"], optional
         OME-NGFF version, by default "0.5".
@@ -3254,7 +3261,7 @@ def open_ome_zarr(
         Whether to allow overwriting a path that does not contain '.zarr',
         by default False
 
-        .. warning::
+        !!! warning
             This can lead to severe data loss
             if the input path is not checked carefully.
 
@@ -3277,9 +3284,9 @@ def open_ome_zarr(
     -------
     Dataset
         NGFF node object
-        (:py:class:`iohub.ngff.Position`,
-        :py:class:`iohub.ngff.Plate`,
-        or :py:class:`iohub.ngff.TiledPosition`)
+        ([`Position`][iohub.ngff.Position],
+        [`Plate`][iohub.ngff.Plate], or
+        [`TiledPosition`][iohub.ngff.TiledPosition])
     """
     if _is_fslike(store_path):
         store_path = Path(store_path)

--- a/src/iohub/ngff/utils.py
+++ b/src/iohub/ngff/utils.py
@@ -349,9 +349,9 @@ def _save_transformed(
     asks numpy for a preposterous allocation.
 
     Gaps arise routinely once the output is sharded along T, because
-    :func:`process_single_position` then batches a whole shard's worth of
-    timepoints into one write and
-    :func:`apply_transform_to_tczyx_and_save` drops the ones whose input was
+    `process_single_position` then batches a whole shard's worth of timepoints
+    into one write and `apply_transform_to_tczyx_and_save` drops the ones whose
+    input was
     all zeros or NaNs from the middle of that batch. They also arise from a
     caller asking for non-consecutive ``output_time_indices`` outright.
     """
@@ -408,7 +408,7 @@ def apply_transform_to_tczyx_and_save(
     Apply a transformation and save the result.
 
     When the write owns its output files outright (see
-    :mod:`iohub.ngff._write_units`) they are cleared before writing rather
+    `iohub.ngff._write_units`) they are cleared before writing rather
     than written over, and completion is recorded in a marker file. Pass
     ``resume=True`` to skip a unit that a previous run already finished.
     """
@@ -577,7 +577,7 @@ def process_single_position(
     resume : bool, optional
         If True, skip shard-aligned ``(time, channel)`` units that a previous
         run already finished, as recorded by the markers described in
-        :mod:`iohub.ngff._write_units`. Intended for retrying a run that was
+        `iohub.ngff._write_units`. Intended for retrying a run that was
         interrupted, for example by Slurm preemption. Leave False when
         re-running with changed inputs or settings,
         since a finished unit is skipped without checking whether it would

--- a/uv.lock
+++ b/uv.lock
@@ -718,6 +718,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "requests" },
+    { name = "ruff" },
     { name = "wget" },
     { name = "zensical" },
 ]
@@ -726,6 +727,7 @@ doc = [
     { name = "mkdocs-click" },
     { name = "mkdocstrings-python" },
     { name = "pymdown-extensions" },
+    { name = "ruff" },
     { name = "zensical" },
 ]
 test = [
@@ -768,22 +770,24 @@ dev = [
     { name = "iohub", extras = ["tensorstore"] },
     { name = "mike", git = "https://github.com/squidfunk/mike.git" },
     { name = "mkdocs-click", specifier = ">=0.9.0" },
-    { name = "mkdocstrings-python", specifier = ">=2.0.5" },
+    { name = "mkdocstrings-python", specifier = ">=2.0.8" },
     { name = "ngff-zarr", extras = ["validate"] },
     { name = "ome-zarr", specifier = ">=0.12.0" },
-    { name = "pymdown-extensions", specifier = ">=11.0.0" },
+    { name = "pymdown-extensions", specifier = ">=11.0.2" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov" },
     { name = "requests", specifier = ">=2.22.0" },
+    { name = "ruff", specifier = ">=0.16.5" },
     { name = "wget", specifier = ">=3.2" },
-    { name = "zensical", specifier = ">=0.0.51" },
+    { name = "zensical", specifier = ">=0.0.57" },
 ]
 doc = [
     { name = "mike", git = "https://github.com/squidfunk/mike.git" },
     { name = "mkdocs-click", specifier = ">=0.9.0" },
-    { name = "mkdocstrings-python", specifier = ">=2.0.5" },
-    { name = "pymdown-extensions", specifier = ">=11.0.0" },
-    { name = "zensical", specifier = ">=0.0.51" },
+    { name = "mkdocstrings-python", specifier = ">=2.0.8" },
+    { name = "pymdown-extensions", specifier = ">=11.0.2" },
+    { name = "ruff", specifier = ">=0.16.5" },
+    { name = "zensical", specifier = ">=0.0.57" },
 ]
 test = [
     { name = "hypothesis", specifier = ">=6.151.0" },
@@ -1116,16 +1120,16 @@ wheels = [
 
 [[package]]
 name = "mkdocstrings-python"
-version = "2.0.5"
+version = "2.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "griffelib" },
     { name = "mkdocs-autorefs" },
     { name = "mkdocstrings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/b6/e858701499d57eee8b3fd8e78168083956c6683ddbe727b46758b19e1119/mkdocstrings_python-2.0.5.tar.gz", hash = "sha256:3a4d92556ad39637e88af94a5374213af9a8e3040c3824ceaed04b486c017594", size = 199578, upload-time = "2026-06-19T10:41:08.868Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/65/0db919b7c91bf033b42d04f15ff16a56f4edd6afb26e84d448359660ece3/mkdocstrings_python-2.0.8.tar.gz", hash = "sha256:34545b54681cf0b212aab95394d37b0f5326a93b102f6ad1df3d965c79384c9d", size = 201771, upload-time = "2026-08-31T20:16:06.698Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/fc/10ab7e80650a9c9e8f4f1105f8c8e73567f88ed0c06ada589ab81d38687c/mkdocstrings_python-2.0.5-py3-none-any.whl", hash = "sha256:30c837bbff016549f659fcba6539ac351303f0fd7e713c89a040611072236e9d", size = 104951, upload-time = "2026-06-19T10:41:07.378Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b7/a5a854d4e44853f26decc0c5e0d68df052399f3da344a313da4178f00816/mkdocstrings_python-2.0.8-py3-none-any.whl", hash = "sha256:e555d9ef53b0febdeae4dd603144d4f86ec90fef672276645ea3bb61232c3d24", size = 105443, upload-time = "2026-08-31T20:16:05.25Z" },
 ]
 
 [[package]]
@@ -1988,15 +1992,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "11.0.1"
+version = "11.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/17/2db4b414de89659144488e0d9c6c0bf0c8395841dc12d81d0532cc6ef310/pymdown_extensions-11.0.2.tar.gz", hash = "sha256:9506fcbe66fa355a775b768084334238dd6805020ac4b92bea0c0dda6f8f223d", size = 855419, upload-time = "2026-08-22T19:28:47.236Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/43/9f45ec4d14e596efc32c925a78104934790438b0c0628b70d741016734ad/pymdown_extensions-11.0.2-py3-none-any.whl", hash = "sha256:259910762019732caa1dfd76f3faa62c59f191d46573e80bcb1d13c0f675bbe5", size = 269929, upload-time = "2026-08-22T19:28:45.389Z" },
 ]
 
 [[package]]
@@ -2254,6 +2258,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
     { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
     { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/85/c8e12473c93018f92d19dd988a294202e1c27426c47ec4de53ffb847b8d8/ruff-0.16.5.tar.gz", hash = "sha256:1b88500f9ffbcab3dedb0082c9f9492e91ec3d618aac1236a3e0189938f7040b", size = 4912003, upload-time = "2026-08-27T16:34:18.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/b6/77c90a970fe2dae17a723acbd011043ea97c98d7deacccefdc4ba74ec512/ruff-0.16.5-py3-none-linux_armv6l.whl", hash = "sha256:12e5f673e774c35fbb62f288809c7653b73445f8ecec6b6063fd6ea3521aa14b", size = 10011941, upload-time = "2026-08-27T16:33:41.287Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/46/6cf67cf6411885a1d6f7f6d801682f155536a85176d10b605e2ceffed8bd/ruff-0.16.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:eda58a5802de40e7ed5b32b64e0b32539338cc6fcd2c78f61e3ad6a0d79f51c3", size = 10204049, upload-time = "2026-08-27T16:33:44.056Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fd/c8720ca7a090abf0c2fef4abe8a5ef6e5127ed15196d8886ff75a2b370e2/ruff-0.16.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5ae9a7b9a8875131f40f8fe967cc86abf899779efd663cb7ce3d572d01da7eb", size = 9809037, upload-time = "2026-08-27T16:33:46.257Z" },
+    { url = "https://files.pythonhosted.org/packages/43/45/a684caacdedaca180f52bacccc40bf0789d2c5a7c75f25324853e9eaedb5/ruff-0.16.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b719b0a1f4d59710d283ab2965f621684a108a9e41da622e3b23f0326cd0025", size = 9964129, upload-time = "2026-08-27T16:33:48.352Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f2/5d2bcdaca6b5b93d1b4dfc166cd2aebf7680143a1b38a28759df13a94d31/ruff-0.16.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2298f2780ed1be0c5cb1361e32ab7b1467f3cce7dabe101d2210a314f2fe42e9", size = 9821518, upload-time = "2026-08-27T16:33:50.57Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ff/011cce29accf9257d5974145b733fc653a37985ed6825413a3987cefbfe0/ruff-0.16.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:258f29035a2dd021e7861e631b227a5b3f14e50c1184c9a6a122c5f4576154d7", size = 10534835, upload-time = "2026-08-27T16:33:52.522Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/5a/f0cf109bada9bba0e96c90c21c9f9251803f57225c32d293327a03c710d6/ruff-0.16.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9a4f0432966834019c74d1b7e5c51224305d7713f3d7faf3e7451f1a3be3cde", size = 11252550, upload-time = "2026-08-27T16:33:54.521Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4d/1d481aaea2046c6a7ed7c291f9004c669cce3c087b6b376ed5b08271e3fe/ruff-0.16.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b5eb3a8c3d0ade9cea42b591fd530368e8798380e30e0a308b85a5cf718f09ea", size = 10777949, upload-time = "2026-08-27T16:33:56.88Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/34/ee245ca55f64443233034b3d02b03236b19242004281247c079390b7facd/ruff-0.16.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef0f69e191a13a3c9816f63163c88790cb12cd157bbbb384e9c44745702ab105", size = 10311656, upload-time = "2026-08-27T16:33:59.12Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/4d/c33a333e341c0a2b96c715b52d89a606f5a34cd4ac493cd9b8d0187186b8/ruff-0.16.5-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:0eeab41fbea2c42f98dfb9822cdccda9d24ba38d49f6dc945b5c236d48f0ef29", size = 10532125, upload-time = "2026-08-27T16:34:01.166Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/a64cef78b40192497bb98a27a8aa8f2c98ee9ee15bc97f7712d94ef32937/ruff-0.16.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f0768e9df4300713fff30733c87575f68b6f1d8de41184e505b7fdd9c0c95eaf", size = 10097648, upload-time = "2026-08-27T16:34:03.16Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4e/4cdc9ed3c3e109d2f71e62572a37457298d7bc7501ec3138babb7ed32bbd/ruff-0.16.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:95cc70cdc7aa80c338de356279d2adbeb2de0f520b9ecd8aba75b94e95e02f91", size = 9829344, upload-time = "2026-08-27T16:34:05.134Z" },
+    { url = "https://files.pythonhosted.org/packages/39/4a/31ed35ce31729955fc583ee0d176d6e784c1290cb0b0a75cb2134c1ab72a/ruff-0.16.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d185c8398ded1bfd91c0c2cb258346307571eccc473a8490af8c3977399c384a", size = 10277117, upload-time = "2026-08-27T16:34:07.425Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a0/60356d86687b4b666d593df213f4dc3041750d024cb7bf2cfa81cfd65c2e/ruff-0.16.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fb8e3a3c4c6a784150a7ced53b015f4b253fc2bf97a610886419ead64b4756ef", size = 10711653, upload-time = "2026-08-27T16:34:09.712Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/20/656d67f5b25ca9bda4e02b1de25867b2954e1d19e03648060f167ad0f4cc/ruff-0.16.5-py3-none-win32.whl", hash = "sha256:288b0a5f080492fe5635db849f9e2e84aa3cce7b7f0e955997d416c507c76a26", size = 10034250, upload-time = "2026-08-27T16:34:11.8Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/42/ee8e68a207b9127fcde6c3d7e197def432f346cb1af159e1fa14ca0d1cdc/ruff-0.16.5-py3-none-win_amd64.whl", hash = "sha256:ddc6385fb2137f616357ca03d6c74f4be987f80fed4008566b754f6032b8546f", size = 10516714, upload-time = "2026-08-27T16:34:13.963Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e3/7df5a396e445b9ba49ce9a9437439a4d80042c61c0ade199abf8d16de1ac/ruff-0.16.5-py3-none-win_arm64.whl", hash = "sha256:a64abe90968719b851bb7cedffaa8753fbdbdadab483089682db623f3edc587e", size = 10391564, upload-time = "2026-08-27T16:34:16.064Z" },
 ]
 
 [[package]]
@@ -2848,7 +2877,7 @@ wheels = [
 
 [[package]]
 name = "zensical"
-version = "0.0.51"
+version = "0.0.57"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -2860,18 +2889,18 @@ dependencies = [
     { name = "pyyaml" },
     { name = "tomli" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/f7/d07ffb268ca86afb26b7f32dbabe25dec03d3aa63ba4d876720c84681d33/zensical-0.0.51.tar.gz", hash = "sha256:de25de067bedfa18f916d7f366fd64a7fbf09bfcc615b44d1ddbe3b5fe02ab49", size = 3979640, upload-time = "2026-07-17T18:08:03.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/f4/fa40086c46a2e59e3d9239031f76623622e60e0d79f3df1282df2797a5c4/zensical-0.0.57.tar.gz", hash = "sha256:25fcbdf89a57153cc3ad1108a89d17c7226da5d3c551a8839c69cbd9c472a9d8", size = 4000458, upload-time = "2026-08-21T20:43:49.5Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/21/02db3e1fb3904016bfac310037c95b9f1eaaf0ffe7b4a84f14263a7d95df/zensical-0.0.51-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:134d776afa526098e05e34713e2f577c075e57a232e01b97842bb0206716afce", size = 12791154, upload-time = "2026-07-17T18:07:20.748Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/35/b0d96f58253514cb3d08f5779020ab01ee5472334fb984b92e3fc9e9c9ac/zensical-0.0.51-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e97ab39668ae3b452c550634e921a0336443743aae5e1fe031c7bb57d049e535", size = 12692190, upload-time = "2026-07-17T18:07:24.553Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/90/7a60e126a10c37c6b789938ff17e73fe76bba707fa029cb40ac659aeaa82/zensical-0.0.51-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c9579809f88608e7aa2cff516fff9d267d74a843cf6088a5f4227de2f092bb5", size = 13139337, upload-time = "2026-07-17T18:07:27.885Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/c3/9101c97b90d4713ef2816db03366a45ae4762efebffd296737a2dd2df325/zensical-0.0.51-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:296dc7a14aa28b81a58eb57df2d5c9c9a4b0de7e90c11d99c943354287952925", size = 13069851, upload-time = "2026-07-17T18:07:31.814Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/79/0474df9e15a2c18f6281a786e10177c1b6e16feac1c568e7f36ad39b339c/zensical-0.0.51-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f779d2d87b4bf228cf2e279bc0ae6bcf3b36a9335ff283a317d01f7c15ae46b2", size = 13451083, upload-time = "2026-07-17T18:07:35.543Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/6f/91bbf78f704d5fd4c0c9be27d6bce3b6e4c2c339e4dcd6e7cf19ecda643c/zensical-0.0.51-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67f813a1514a90890ca86248a8d54b81b2164bcbff11a6bcf11b01e1c01a1454", size = 13110446, upload-time = "2026-07-17T18:07:38.783Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/89/aa9a95f81771614c37bdc52b8ab21fcdef4c8de7c9cedf34e9bf62674281/zensical-0.0.51-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:186ef37e0eee0e969e2cfae47b1b97775e3164e2cba95c71faa4dd6ef47ed009", size = 13315871, upload-time = "2026-07-17T18:07:42.43Z" },
-    { url = "https://files.pythonhosted.org/packages/08/11/1bf6e9ded29d376f8c12644cc4de04676b010fee8caa17f682606b1f16d5/zensical-0.0.51-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:f5d91ce246ed930224603083cef02ae8947132fc7c52901d72015ea03526fa58", size = 13344382, upload-time = "2026-07-17T18:07:46.066Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/ec/663f16ff82d08b212e7c3236a88bd332f73331f94ddac1c91aaf882bbd1e/zensical-0.0.51-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:b1108eae82c6e8ffc33026f60b485c1512647a5333be4f547166b7c8877b98af", size = 13499628, upload-time = "2026-07-17T18:07:49.196Z" },
-    { url = "https://files.pythonhosted.org/packages/60/b4/7f1b6c3cf06d9f6ff5216523168a5d6ccc693444d5ceeb911eca97b30d98/zensical-0.0.51-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6fa0ecaf14f56841bfc595fa141396350c72aafbec73a016ebe3c824ed21ac72", size = 13451420, upload-time = "2026-07-17T18:07:52.563Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/44/be4bc09ec8f69e7be1b07b875887961c4e0e478b03a10d2cc624ef28fbe6/zensical-0.0.51-cp310-abi3-win32.whl", hash = "sha256:fb7ff4946b72168759c6af0a29cf5de4c38aebe633a83292e8cd4145b5213cc2", size = 12375639, upload-time = "2026-07-17T18:07:56.081Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/85/aa827c244ed4f404e99a91c3ecf5e5adb62eca806a9e9c8e3333bbad8660/zensical-0.0.51-cp310-abi3-win_amd64.whl", hash = "sha256:12529d3d3991b63820952111dc1d1edc29b2c9b3a3abb16c243bcb649631ebf2", size = 12628965, upload-time = "2026-07-17T18:07:59.741Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b9/49c37dc65105d1ca4a8b600a02c84ece00218d2293b2630611c620185ca3/zensical-0.0.57-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:98867d1a6ea2c57f1ebcf4902f61601f427350f2df0c04e30cfac8ba6163cd29", size = 12888507, upload-time = "2026-08-21T20:43:20.365Z" },
+    { url = "https://files.pythonhosted.org/packages/05/f7/54539984418de11387bbace39a744195555d32c98c95bf4d112b432548f5/zensical-0.0.57-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:0d7935d77d73a279545052e05d89d31960f30c1f33f53933f4c101fa271aee74", size = 12778169, upload-time = "2026-08-21T20:43:22.879Z" },
+    { url = "https://files.pythonhosted.org/packages/40/16/74aa60aa4cfecd5bd31ce60cb6a092cb56f1bc1aaadcc173463861ea4eb5/zensical-0.0.57-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b7046d433511d97aa603915f0f6792d15b7f839793abc2b66ab7b7ff753ecff5", size = 13230823, upload-time = "2026-08-21T20:43:25.141Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/d1/742d2487dd65dd18277daebcd37db56d5bd4a2408df02bde703ef8fb7b64/zensical-0.0.57-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ab85c5066b95e3a877cf8971e4ce30abb1ca1459fbfcc631f0a5a2bab56351a4", size = 13170523, upload-time = "2026-08-21T20:43:27.456Z" },
+    { url = "https://files.pythonhosted.org/packages/56/6f/12b570775d344f1a3d77e26d4ae0160bcac9e41ca38f7135352ccdf9b2c8/zensical-0.0.57-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0f13d1b57ad3c8b8634933a93ea870ebac11245fe0c968d27fd2a059ee1c6311", size = 13549941, upload-time = "2026-08-21T20:43:29.964Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/4e/436e6fc76674244c084ef7f6f17dc5ff85c76b15aef77c48b703fd0a2dda/zensical-0.0.57-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:021dd8fb70d1816cd012684fcf45d32b8f88a0cd28b7cbe71e5f8564f6d5764d", size = 13210086, upload-time = "2026-08-21T20:43:32.098Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/52/20f3aeda9af1090f24241670a5cc20fff7494545fea9f5fa094c82f3dbdf/zensical-0.0.57-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7e10f3c27fdc3eac3a9ae6ddcd87f3f00edc9f332050923313c95537961bfadd", size = 13408253, upload-time = "2026-08-21T20:43:34.258Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f2/2b18ba2f19674dbfcf745f3b66e005cc8efa66a1bcaba5e1b4f79467868a/zensical-0.0.57-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:78c85fee55c5aac3bdf8157e980c56397dca835167a5577c5429b5eb24ed990c", size = 13446689, upload-time = "2026-08-21T20:43:36.527Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ba/68cdba447a9097e5f97742eef046020c6fa42d82972849b3a46a0718e890/zensical-0.0.57-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:478d252e1924f3876e72cf7806967cb62e50d86eddb3da04bf43e882b532fa1b", size = 13598580, upload-time = "2026-08-21T20:43:38.646Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/89/6358a4df272328bed5bea90b04d43e73758bc45ff058c5cb2665e1147314/zensical-0.0.57-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66a9ca6b5f625b2a2b215eec2f3c72843a92d5d512042045ac6351d5dee9b339", size = 13557609, upload-time = "2026-08-21T20:43:40.866Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e1/8831301a24f736743e3788f09ea048918b0bdcea4aaa90f7770a433d6eec/zensical-0.0.57-cp310-abi3-win32.whl", hash = "sha256:f0fe3dc27ca7dc4e168eddd0fe5b0f4d44e311fd4e0019241e289819e445203c", size = 12446805, upload-time = "2026-08-21T20:43:43.097Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/3f/5d0ecd77d9ce962fdfde22dec036f4257a43ef6dbd55fb5c05fd294985ad/zensical-0.0.57-cp310-abi3-win_amd64.whl", hash = "sha256:a756834025c1c54e806e943be6d8df1048d0f8bcf6086e958568407a070a2572", size = 12716781, upload-time = "2026-08-21T20:43:45.273Z" },
 ]

--- a/zensical.toml
+++ b/zensical.toml
@@ -68,6 +68,7 @@ nav = [
     "api/ngff.md",
     "api/readers.md",
     "api/converter.md",
+    "api/utils.md",
   ] },
   { "Contributing" = "contributing.md" },
 ]
@@ -346,6 +347,16 @@ show_source = false
 show_root_heading = true
 show_root_full_path = false
 members_order = "source"
+separate_signature = true
+line_length = 120
+docstring_section_style = "list"
+show_signature_annotations = true
+annotations_path = "brief"
+modernize_annotations = true
+merge_init_into_class = true
+show_symbol_type_heading = true
+show_symbol_type_toc = true
+show_inheritance_diagram = true
 
 # ----------------------------------------------------------------------------
 # Markdown extensions configuration

--- a/zensical.toml
+++ b/zensical.toml
@@ -356,7 +356,6 @@ modernize_annotations = true
 merge_init_into_class = true
 show_symbol_type_heading = true
 show_symbol_type_toc = true
-show_inheritance_diagram = true
 
 # ----------------------------------------------------------------------------
 # Markdown extensions configuration


### PR DESCRIPTION
Signed-off-by: Sricharan Reddy Varra <sricharan.varra@biohub.org>

## Related issue

<!-- Link the issue this pull request addresses, for example: Closes #123. -->

Issue #420.

## Summary

<!-- Describe what this pull request changes and why. -->

- Document the public functions in `iohub.ngff.utils`.
- Update the conversion page to include TIFF, NDTiff, and Nikon ND2 inputs.
- Render parameters as lists instead of tables.
- Format long signatures with Ruff and show type annotations, symbol labels, and inheritance diagrams.
- Replace Sphinx-only roles and directives with Markdown that `mkdocstrings` and Zensical render correctly.
- Update the documentation dependencies and uv.lock.

## Testing

Here's what it looks like on main:
<img width="2467" height="1512" alt="Screenshot 2026-08-31 at 5 28 13 PM" src="https://github.com/user-attachments/assets/edaaf7ed-cdfa-45b9-af0a-1f480f0a239e" />


And on this pr:
<img width="2467" height="1512" alt="Screenshot 2026-08-31 at 5 28 20 PM" src="https://github.com/user-attachments/assets/3925b180-3584-4c3d-87e6-589fb256a768" />

## Checklist

- [x] I added or updated tests, or this change does not require tests.
- [x] I updated the documentation, or this change does not require documentation.
- [x] I confirmed this change does not include confidential or sensitive information.

